### PR TITLE
Fix cast error in percentile-based outlier detection; use 0.99 instea…

### DIFF
--- a/bench/batch_template.conf
+++ b/bench/batch_template.conf
@@ -13,7 +13,7 @@ useZScore: false
 zScore: 3.0
 
 usePercentile: true
-targetPercentile: 0.01
+targetPercentile: 0.99
 
 useDiskCache: true
 diskCacheDirectory: sql_cache

--- a/bench/streaming_template.conf
+++ b/bench/streaming_template.conf
@@ -13,7 +13,7 @@ useZScore: false
 zScore: 3.0
 
 usePercentile: true
-targetPercentile: 0.01
+targetPercentile: 0.99
 
 inputReservoirSize: %(inputReservoirSize)d
 scoreReservoirSize: %(scoreReservoirSize)d

--- a/conf/batch.yaml
+++ b/conf/batch.yaml
@@ -16,7 +16,7 @@ useZScore: false
 zScore: 3.0
 
 usePercentile: true
-targetPercentile: 0.01
+targetPercentile: 0.99
 
 logging:
   level: INFO

--- a/conf/streaming.yaml
+++ b/conf/streaming.yaml
@@ -16,7 +16,7 @@ useZScore: false
 zScore: 3.0
 
 usePercentile: true
-targetPercentile: 0.01
+targetPercentile: 0.99
 
 inputReservoirSize: 10000
 scoreReservoirSize: 10000

--- a/src/main/java/macrobase/analysis/outlier/OutlierDetector.java
+++ b/src/main/java/macrobase/analysis/outlier/OutlierDetector.java
@@ -61,7 +61,7 @@ public abstract class OutlierDetector {
         Double thresh = cachedPercentileEquivalents.get(score);
         if(thresh == null) {
             recentScores.sort((a, b) -> a.compareTo(b));
-            thresh = recentScores.get((int)targetPercentile*recentScores.size());
+            thresh = recentScores.get((int)(targetPercentile*recentScores.size()));
             cachedPercentileEquivalents.put(score, thresh);
         }
 


### PR DESCRIPTION
…d of 0.01 by default.