### PR TITLE
Adding stress tester and fixing two bugs in StreamingFPGrowth. Should fix #25.

### DIFF
--- a/src/test/java/macrobase/summary/itemset/StreamingFPGrowthTest.java
+++ b/src/test/java/macrobase/summary/itemset/StreamingFPGrowthTest.java
@@ -1,7 +1,9 @@
 package macrobase.summary.itemset;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import jdk.nashorn.internal.ir.annotations.Ignore;
 import macrobase.analysis.summary.itemset.Apriori;
 import macrobase.analysis.summary.itemset.FPGrowth;
 import macrobase.analysis.summary.itemset.StreamingFPGrowth;
@@ -139,5 +141,33 @@ public class StreamingFPGrowthTest {
         printItemsets(Lists.newArrayList(apItemsets));
 
         assertEquals(apItemsets.size(), itemsets.size());
+    }
+
+    @Ignore
+    @Test
+    public void stress() {
+        StreamingFPGrowth fp = new StreamingFPGrowth(.001);
+        Random random = new Random();
+        int cnt = 0;
+
+        Map<Integer, Double> frequentItems = new HashMap<>();
+        for(cnt = 0; cnt <= 100000000; ++cnt) {
+            int itemSetSize = random.nextInt(100);
+            Set<Integer> itemSet = new HashSet<>(itemSetSize);
+            for(int i = 0; i < itemSetSize; ++i) {
+                itemSet.add(random.nextInt(100));
+                frequentItems.compute(i, (k, v) -> v == null ? 1 : v + 1);
+            }
+
+            fp.insertTransactionStreamingFalseNegative(itemSet);
+
+            if(cnt % 1000 == 0) {
+                int toDecay = random.nextInt(frequentItems.size());
+                for(int i = 0; i < toDecay; ++i) {
+                    frequentItems.remove(frequentItems.keySet().toArray()[random.nextInt(frequentItems.size())]);
+                }
+                fp.decayAndResetFrequentItems(frequentItems, .95);
+            }
+        }
     }
 }


### PR DESCRIPTION
I wrote a stress test for the StreamingFPTree and found two bugs, one of which should correspond to #25.

*Bug one:* When we merge two nodes, and the receiving node doesn't have any children, it needs to be marked as a leaf node. Otherwise, the node is removed from the tree twice [L169](https://github.com/stanford-futuredata/macrobase/commit/928636ed92ccd6d9197bbf903ddea9cdc03e5a81#diff-17a5f28a45018f3282473cce06fb484fR169).

*Bug two:* We should only remove a node from the tree when it no longer has children; this seems paradoxical but can be possible with low precision doubles (or if someone inserts a transaction with count zero) [L640](https://github.com/stanford-futuredata/macrobase/compare/master...fptree-fixes#diff-17a5f28a45018f3282473cce06fb484fR640). I believe this is actually a bug instead of just hiding another behavior; the stress test doesn't pass otherwise.