### PR TITLE
Fix off-by-one and construction errors in memory caching loader.

### DIFF
--- a/src/main/java/macrobase/ingest/DatumEncoder.java
+++ b/src/main/java/macrobase/ingest/DatumEncoder.java
@@ -1,10 +1,8 @@
 package macrobase.ingest;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Maps;
-
 import macrobase.ingest.result.ColumnValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class DatumEncoder {
+    private static final Logger log = LoggerFactory.getLogger(DatumEncoder.class);
+
     private HashMap<Integer, String> attributeDimensionNameMap = new HashMap<>();
     private HashMap<Integer, Map<String, Integer>> integerEncoding = new HashMap<>();
     private HashMap<Integer, Integer> integerToColumn = new HashMap<>();
@@ -27,27 +27,24 @@ public class DatumEncoder {
         for(Map.Entry<Integer, String> entry : attributeDimensionNameMap.entrySet()) {
             int dim = entry.getKey();
             if(oldToNewRemapping.containsKey(dim)) {
-                dim = oldToNewRemapping.get(dim);
+                newAttributeDimensionNameMap.put(oldToNewRemapping.get(dim), entry.getValue());
             }
-            newAttributeDimensionNameMap.put(dim, entry.getValue());
         }
 
         for(Map.Entry<Integer, Map<String, Integer>> entry :
                 integerEncoding.entrySet()) {
             int dim = entry.getKey();
             if(oldToNewRemapping.containsKey(dim)) {
-                dim = oldToNewRemapping.get(dim);
+                newIntegerEncoding.put(oldToNewRemapping.get(dim), entry.getValue());
             }
-            newIntegerEncoding.put(dim, entry.getValue());
         }
 
         for(Map.Entry<Integer, Integer> entry :
                 integerToColumn.entrySet()) {
-            int dim = entry.getKey();
+            int dim = entry.getValue();
             if(oldToNewRemapping.containsKey(dim)) {
-                dim = oldToNewRemapping.get(dim);
+                newIntegerToColumn.put(entry.getKey(), oldToNewRemapping.get(entry.getValue()));
             }
-            newIntegerToColumn.put(dim, entry.getValue());
         }
 
         attributeDimensionNameMap = newAttributeDimensionNameMap;

--- a/src/main/java/macrobase/ingest/MemoryCachingSQLLoader.java
+++ b/src/main/java/macrobase/ingest/MemoryCachingSQLLoader.java
@@ -143,16 +143,16 @@ abstract public class MemoryCachingSQLLoader extends SQLLoader {
                      checkMatchingBaseQuery(cached.getBaseQuery(), baseQuery)) {
                 log.debug("Returning (subset of metrics) cached data!");
 
-
                 // mapping from old metric to new metric
                 HashMap<Integer, Integer> oldToNewAttributeDimension = new HashMap<>();
-                int newAttributeIndex = 0;
+                int newAttributeIndex = 1;
                 for(String attribute : attributes) {
-                    int oldIndex = cached.getAttributes().indexOf(attribute);
+                    int oldIndex = cached.getAttributes().indexOf(attribute)+1;
                     oldToNewAttributeDimension.put(oldIndex, newAttributeIndex);
                     newAttributeIndex++;
                 }
 
+                encoder.copy(cached.getEncoder());
                 encoder.updateAttributeDimensions(oldToNewAttributeDimension);
 
                 // mapping from old metric to new metric


### PR DESCRIPTION
This class either needs rewrite or removal. I had to fix it to get the demo working again, but I think that it's simultaneously too clever and too dumb for its own good.

This reminds me that `DatumEncoder` is also a bit of a mess.