### PR TITLE
Make detector class configurable.

### DIFF
--- a/conf/batch.yaml
+++ b/conf/batch.yaml
@@ -3,6 +3,9 @@ targetAttributes: [userid]
 targetLowMetrics: [data_count_minutes]
 targetHighMetrics: []
 
+# MAD, MCD, ZSCORE
+outlierDetectorType: MCD
+
 dbUrl: postgres
 baseQuery: SELECT * FROM mapmatch_history H, sf_datasets D WHERE H.dataset_id = D.id LIMIT 100000;
 

--- a/conf/streaming.yaml
+++ b/conf/streaming.yaml
@@ -3,6 +3,9 @@ targetAttributes: [userid, app_version]
 targetLowMetrics: [data_count_minutes]
 targetHighMetrics: []
 
+# MAD, MCD, ZSCORE
+outlierDetectorType: MCD
+
 dbUrl: postgres
 baseQuery: SELECT * FROM mapmatch_history H, sf_datasets D WHERE H.dataset_id = D.id LIMIT 10000000;
 

--- a/src/main/java/macrobase/analysis/BatchAnalyzer.java
+++ b/src/main/java/macrobase/analysis/BatchAnalyzer.java
@@ -5,6 +5,7 @@ import com.google.common.base.Stopwatch;
 import macrobase.analysis.outlier.MAD;
 import macrobase.analysis.outlier.MinCovDet;
 import macrobase.analysis.outlier.OutlierDetector;
+import macrobase.analysis.outlier.ZScore;
 import macrobase.analysis.result.AnalysisResult;
 import macrobase.analysis.summary.itemset.FPGrowthEmerging;
 import macrobase.analysis.summary.itemset.result.ItemsetResult;
@@ -12,6 +13,7 @@ import macrobase.datamodel.Datum;
 import macrobase.ingest.DatumEncoder;
 import macrobase.ingest.SQLLoader;
 
+import macrobase.runtime.standalone.BaseStandaloneConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,13 +51,8 @@ public class BatchAnalyzer extends BaseAnalyzer {
         log.debug("...ended loading (time: {}ms)!", loadTime);
 
         sw.start();
-        OutlierDetector detector;
         int metricsDimensions = lowMetrics.size() + highMetrics.size();
-        if(metricsDimensions == 1) {
-            detector = new MAD();
-        } else {
-            detector = new MinCovDet(metricsDimensions);
-        }
+        OutlierDetector detector = constructDetector(metricsDimensions);
 
         OutlierDetector.BatchResult or;
         if(forceUsePercentile || (!forceUseZScore && TARGET_PERCENTILE > 0)) {

--- a/src/main/java/macrobase/analysis/StreamingAnalyzer.java
+++ b/src/main/java/macrobase/analysis/StreamingAnalyzer.java
@@ -117,13 +117,8 @@ public class StreamingAnalyzer extends BaseAnalyzer {
 
         //System.console().readLine("waiting to start (press a key)");
 
-        OutlierDetector detector;
         int metricsDimensions = lowMetrics.size() + highMetrics.size();
-        if(metricsDimensions == 1) {
-            detector = new MAD();
-        } else {
-            detector = new MinCovDet(metricsDimensions, alphaMCD, stoppingDeltaMCD);
-        }
+        OutlierDetector detector = constructDetector(metricsDimensions);
 
         ExponentiallyBiasedAChao<Datum> inputReservoir =
                 new ExponentiallyBiasedAChao<>(inputReservoirSize, decayRate);

--- a/src/main/java/macrobase/runtime/standalone/BaseStandaloneConfiguration.java
+++ b/src/main/java/macrobase/runtime/standalone/BaseStandaloneConfiguration.java
@@ -11,6 +11,16 @@ import java.util.List;
  * Created by pbailis on 12/24/15.
  */
 public class BaseStandaloneConfiguration extends Configuration {
+
+    public enum DetectorType {
+        MAD,
+        MCD,
+        ZSCORE
+    }
+
+    @JsonProperty
+    private DetectorType outlierDetectorType;
+
     @NotEmpty
     private String taskName;
 
@@ -98,6 +108,9 @@ public class BaseStandaloneConfiguration extends Configuration {
     public double getMinSupport() {
         return minSupport;
     }
+
+    @JsonProperty
+    public DetectorType getDetectorType() { return outlierDetectorType; }
 
     @JsonProperty
     public double getMinInlierRatio() {

--- a/src/main/java/macrobase/runtime/standalone/batch/MacroBaseBatchCommand.java
+++ b/src/main/java/macrobase/runtime/standalone/batch/MacroBaseBatchCommand.java
@@ -33,6 +33,7 @@ public class MacroBaseBatchCommand extends ConfiguredCommand<BatchStandaloneConf
         loader.connect(configuration.getDbUrl());
 
         BatchAnalyzer analyzer = new BatchAnalyzer();
+        analyzer.setDetectorType(configuration.getDetectorType());
         analyzer.setMinInlierRatio(configuration.getMinInlierRatio());
         analyzer.setMinSupport(configuration.getMinSupport());
         analyzer.setTargetPercentile(configuration.getTargetPercentile());

--- a/src/main/java/macrobase/runtime/standalone/streaming/MacroBaseStreamingCommand.java
+++ b/src/main/java/macrobase/runtime/standalone/streaming/MacroBaseStreamingCommand.java
@@ -62,6 +62,7 @@ public class MacroBaseStreamingCommand extends ConfiguredCommand<StreamingStanda
         analyzer.forceUsePercentile(configuration.usePercentile());
         analyzer.forceUseZScore(configuration.useZScore());
 
+        analyzer.setDetectorType(configuration.getDetectorType());
         analyzer.setDecayRate(configuration.getDecayRate());
         analyzer.setInputReservoirSize(configuration.getInputReservoirSize());
         analyzer.setScoreReservoirSize(configuration.getScoreReservoirSize());


### PR DESCRIPTION
Defaults to MAD for 1 dimension, MCD for 2+. Preserves backwards compatibility. @deepakn94 