### PR TITLE
Add option to disable tracing in inner loop for streaming.

### DIFF
--- a/src/main/java/macrobase/analysis/StreamingAnalyzer.java
+++ b/src/main/java/macrobase/analysis/StreamingAnalyzer.java
@@ -81,6 +81,10 @@ public class StreamingAnalyzer extends BaseAnalyzer {
         this.minRatio = minRatio;
     }
 
+    public void setTracing(boolean doTrace) {
+        this.doTrace = doTrace;
+    }
+
     public void setOutlierItemSummarySize(Integer outlierItemSummarySize) {
         this.outlierItemSummarySize = outlierItemSummarySize;
     }
@@ -88,6 +92,14 @@ public class StreamingAnalyzer extends BaseAnalyzer {
     public void setInlierItemSummarySize(Integer inlierItemSummarySize) {
         this.inlierItemSummarySize = inlierItemSummarySize;
     }
+
+    boolean doTrace;
+
+    int tupleNo = 0;
+    long totODTrainingTime = 0;
+    long totSummarizationTrainingTime = 0;
+    long totScoringTime = 0;
+    long totSummarizationTime = 0;
 
     public AnalysisResult analyzeOnePass(SQLLoader loader,
                                               List<String> attributes,
@@ -168,11 +180,11 @@ public class StreamingAnalyzer extends BaseAnalyzer {
                                                          streamingSummarizer);
         }
 
-        int tupleNo = 0;
-        long totODTrainingTime = 0;
-        long totSummarizationTrainingTime = 0;
-        long totScoringTime = 0;
-        long totSummarizationTime = 0;
+        tupleNo = 0;
+        totODTrainingTime = 0;
+        totSummarizationTrainingTime = 0;
+        totScoringTime = 0;
+        totSummarizationTime = 0;
 
         for(Datum d: data) {
             inputReservoir.insert(d);
@@ -184,43 +196,28 @@ public class StreamingAnalyzer extends BaseAnalyzer {
                 }
                 detector.updateRecentScoreList(scoreReservoir.getReservoir());
             } else if(tupleNo >= warmupCount) {
-                // todo: calling curtime so frequently might be bad...
-                long now = System.currentTimeMillis();
-
-                sw.start();
-                analysisUpdater.updateIfNecessary(now, tupleNo);
-                sw.stop();
-                sw.reset();
-                totSummarizationTrainingTime += sw.elapsed(TimeUnit.MICROSECONDS);
-
-                sw.start();
-                modelUpdater.updateIfNecessary(now, tupleNo);
-                sw.stop();
-                totODTrainingTime += sw.elapsed(TimeUnit.MICROSECONDS);
-                sw.reset();
-
-                // classify, then insert into tree, etc.
-                sw.start();
-                double score = detector.score(d);
-                sw.stop();
-                totScoringTime += sw.elapsed(TimeUnit.MICROSECONDS);
-                sw.reset();
-
-                sw.start();
-                if(scoreReservoir != null) {
-                    scoreReservoir.insert(score);
-                }
-
-                if((forceUseZScore && detector.isZScoreOutlier(score, ZSCORE)) ||
-                   forceUsePercentile && detector.isPercentileOutlier(score,
-                                                                      TARGET_PERCENTILE)) {
-                    streamingSummarizer.markOutlier(d);
+                if(doTrace) {
+                    innerLoopTracing(sw, detector, scoreReservoir, streamingSummarizer, analysisUpdater, modelUpdater, d);
                 } else {
-                    streamingSummarizer.markInlier(d);
+                    long now = useRealTimePeriod ? System.currentTimeMillis() : 0;
+
+                    analysisUpdater.updateIfNecessary(now, tupleNo);
+                    modelUpdater.updateIfNecessary(now, tupleNo);
+                    double score = detector.score(d);
+
+                    if(scoreReservoir != null) {
+                        scoreReservoir.insert(score);
+                    }
+
+                    if((forceUseZScore && detector.isZScoreOutlier(score, ZSCORE)) ||
+                       forceUsePercentile && detector.isPercentileOutlier(score,
+                                                                          TARGET_PERCENTILE)) {
+                        streamingSummarizer.markOutlier(d);
+                    } else {
+                        streamingSummarizer.markInlier(d);
+                    }
                 }
-                sw.stop();
-                totSummarizationTime += sw.elapsed(TimeUnit.MICROSECONDS);
-                sw.reset();
+
             }
 
             tupleNo += 1;
@@ -245,9 +242,47 @@ public class StreamingAnalyzer extends BaseAnalyzer {
 
         log.debug("Number of itemsets: {}", isr.size());
 
-        //System.console().readLine("Finished! Press any key to continue");
-
         return new AnalysisResult(0, 0, loadTime, totScoringTime + totODTrainingTime + totSummarizationTrainingTime, totSummarizationTime, isr);
+    }
+
+    private void innerLoopTracing(Stopwatch sw, OutlierDetector detector, ExponentiallyBiasedAChao<Double> scoreReservoir, ExponentiallyDecayingEmergingItemsets streamingSummarizer, AbstractPeriodicUpdater analysisUpdater, AbstractPeriodicUpdater modelUpdater, Datum d) {
+        // todo: calling curtime so frequently might be bad...
+        long now = useRealTimePeriod ? System.currentTimeMillis() : 0;
+
+        sw.start();
+        analysisUpdater.updateIfNecessary(now, tupleNo);
+        sw.stop();
+        sw.reset();
+        totSummarizationTrainingTime += sw.elapsed(TimeUnit.MICROSECONDS);
+
+        sw.start();
+        modelUpdater.updateIfNecessary(now, tupleNo);
+        sw.stop();
+        totODTrainingTime += sw.elapsed(TimeUnit.MICROSECONDS);
+        sw.reset();
+
+        // classify, then insert into tree, etc.
+        sw.start();
+        double score = detector.score(d);
+        sw.stop();
+        totScoringTime += sw.elapsed(TimeUnit.MICROSECONDS);
+        sw.reset();
+
+        sw.start();
+        if(scoreReservoir != null) {
+            scoreReservoir.insert(score);
+        }
+
+        if((forceUseZScore && detector.isZScoreOutlier(score, ZSCORE)) ||
+           forceUsePercentile && detector.isPercentileOutlier(score,
+                                                              TARGET_PERCENTILE)) {
+            streamingSummarizer.markOutlier(d);
+        } else {
+            streamingSummarizer.markInlier(d);
+        }
+        sw.stop();
+        totSummarizationTime += sw.elapsed(TimeUnit.MICROSECONDS);
+        sw.reset();
     }
 
     public void setWarmupCount(Integer warmupCount) {

--- a/src/main/java/macrobase/runtime/standalone/streaming/MacroBaseStreamingCommand.java
+++ b/src/main/java/macrobase/runtime/standalone/streaming/MacroBaseStreamingCommand.java
@@ -75,6 +75,7 @@ public class MacroBaseStreamingCommand extends ConfiguredCommand<StreamingStanda
         analyzer.setOutlierItemSummarySize(configuration.getOutlierItemSummarySize());
         analyzer.setMinSupportOutlier(configuration.getMinSupport());
         analyzer.setMinRatio(configuration.getMinInlierRatio());
+        analyzer.setTracing(configuration.traceRuntime());
         
         analyzer.setAlphaMCD(configuration.getAlphaMCD());
         analyzer.setStoppingDeltaMCD(configuration.getStoppingDeltaMCD());

--- a/src/main/java/macrobase/runtime/standalone/streaming/StreamingStandaloneConfiguration.java
+++ b/src/main/java/macrobase/runtime/standalone/streaming/StreamingStandaloneConfiguration.java
@@ -13,6 +13,8 @@ public class StreamingStandaloneConfiguration extends BaseStandaloneConfiguratio
     @NotNull
     private Integer summaryRefreshPeriod;
 
+    private Boolean traceRuntime = false;
+
     @NotNull
     private Boolean useRealTimePeriod;
 
@@ -75,4 +77,7 @@ public class StreamingStandaloneConfiguration extends BaseStandaloneConfiguratio
 
     @JsonProperty
     public Integer getOutlierItemSummarySize() { return outlierItemSummarySize; }
+
+    @JsonProperty
+    public Boolean traceRuntime() { return traceRuntime; }
 }


### PR DESCRIPTION
This PR makes fine-grained timing for the streaming inner loop configurable (default: off). Since Java doesn't have pre-processor macros, there were a few ways to go. This is one of the simplest but the least generic.

@deepakn94: any thoughts?