### PR TITLE
FP-Growth batch fixes

### DIFF
--- a/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
@@ -255,15 +255,15 @@ public class FPGrowth {
                     if(pattern.contains(curNode.getItem())) {
                         itemsToFind -= 1;
                     }
-                    curNode = curNode.getParent();
 
                     if(itemsToFind == 0) {
-                        count += pathHead.count;
+                        count += curNode.count;
                         break;
                     }
 
-                    curNode = curNode.getNextLink();
+                    curNode = curNode.getParent();
                 }
+                pathHead = pathHead.getNextLink();
             }
 
             return count;

--- a/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
@@ -209,8 +209,11 @@ public class FPGrowth {
             for(DatumWithScore d : datums) {
                 List<Integer> filtered = d.getDatum().getAttributes().stream().filter(
                         i -> frequentItemCounts.containsKey(i)).collect(Collectors.toList());
-                filtered.sort((i1, i2) -> frequentItemOrder.get(i2).compareTo(frequentItemOrder.get(i1)));
-                root.insertTransaction(filtered, 0, 1);
+
+                if(!filtered.isEmpty()) {
+                    filtered.sort((i1, i2) -> frequentItemOrder.get(i2).compareTo(frequentItemOrder.get(i1)));
+                    root.insertTransaction(filtered, 0, 1);
+                }
             }
         }
 
@@ -406,16 +409,32 @@ public class FPGrowth {
         }
     }
 
-    public List<ItemsetWithCount> getItemsets(List<Set<Integer>> transactions,
-                                              Double support) {
-        return getItemsets(transactions, null, support);
+
+
+
+
+    public List<ItemsetWithCount> getItemsetsWithSupportRatio(List<Set<Integer>> transactions,
+                                                              Double supportRatio) {
+        return getItemsetsWithSupportRatio(transactions, null, supportRatio);
     }
 
-    public List<ItemsetWithCount> getItemsets(List<Set<Integer>> transactions,
-                                              Map<Integer, Double> initialCounts,
-                                              Double support) {
+    public List<ItemsetWithCount> getItemsetsWithSupportRatio(List<Set<Integer>> transactions,
+                                                              Map<Integer, Double> initialCounts,
+                                                              Double supportRatio) {
+        return getItemsetsWithSupportCount(transactions, initialCounts, supportRatio*transactions.size());
+    }
+
+    public List<ItemsetWithCount> getItemsetsWithSupportCount(List<Set<Integer>> transactions,
+                                                              Double supportCount) {
+        return getItemsetsWithSupportCount(transactions, null, supportCount);
+
+    }
+
+    public List<ItemsetWithCount> getItemsetsWithSupportCount(List<Set<Integer>> transactions,
+                                                              Map<Integer, Double> initialCounts,
+                                                              Double supportCount) {
         FPTree fp = new FPTree();
-        int countRequiredForSupport = (int)(support*transactions.size());
+        int countRequiredForSupport = supportCount.intValue();
         log.debug("count required: {}", countRequiredForSupport);
 
         long st = System.currentTimeMillis();

--- a/src/main/java/macrobase/analysis/summary/itemset/FPGrowthEmerging.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/FPGrowthEmerging.java
@@ -80,7 +80,8 @@ public class FPGrowthEmerging {
 
         context = outlierFPGrowth.time();
         FPGrowth fpg = new FPGrowth();
-        List<ItemsetWithCount> iwc = fpg.getItemsets(outlierTransactions, supportedOutlierCounts, minSupport);
+        List<ItemsetWithCount> iwc = fpg.getItemsetsWithSupportCount(outlierTransactions, supportedOutlierCounts,
+                                                                     outliers.size()*minSupport);
         context.stop();
 
         context = inlierRatio.time();

--- a/src/test/java/macrobase/summary/itemset/FPGrowthTest.java
+++ b/src/test/java/macrobase/summary/itemset/FPGrowthTest.java
@@ -49,7 +49,7 @@ public class FPGrowthTest {
 
         FPGrowth fp = new FPGrowth();
 
-        List<ItemsetWithCount> itemsets = fp.getItemsets(txns, .6);
+        List<ItemsetWithCount> itemsets = fp.getItemsetsWithSupportRatio(txns, .6);
 
         //printItemsets(itemsets);
 
@@ -66,7 +66,7 @@ public class FPGrowthTest {
 
         FPGrowth fp = new FPGrowth();
 
-        List<ItemsetWithCount> itemsets = fp.getItemsets(txns, .2);
+        List<ItemsetWithCount> itemsets = fp.getItemsetsWithSupportRatio(txns, .2);
 
         Apriori ap = new Apriori();
         Set<ItemsetWithCount> api = ap.getItemsets(txns, .2);
@@ -99,7 +99,7 @@ public class FPGrowthTest {
 
         FPGrowth fp = new FPGrowth();
 
-        List<ItemsetWithCount> itemsets = fp.getItemsets(txns, .7);
+        List<ItemsetWithCount> itemsets = fp.getItemsetsWithSupportRatio(txns, .7);
 
         //printItemsets(itemsets);
 
@@ -126,7 +126,7 @@ public class FPGrowthTest {
 
         FPGrowth fp = new FPGrowth();
 
-        List<ItemsetWithCount> itemsets = fp.getItemsets(txns, .01);
+        List<ItemsetWithCount> itemsets = fp.getItemsetsWithSupportRatio(txns, .01);
 
         List<Set<Integer>> apil = itemsets.stream().map(i -> i.getItems()).collect(Collectors.toList());
         Set<Set<Integer>> dupdetector = new HashSet<>();

--- a/src/test/java/macrobase/summary/itemset/StreamingFPGrowthTest.java
+++ b/src/test/java/macrobase/summary/itemset/StreamingFPGrowthTest.java
@@ -7,7 +7,6 @@ import macrobase.analysis.summary.itemset.FPGrowth;
 import macrobase.analysis.summary.itemset.StreamingFPGrowth;
 import macrobase.analysis.summary.itemset.result.ItemsetWithCount;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,7 @@ public class StreamingFPGrowthTest {
 
         fp.buildTree(allTxns);
         List<ItemsetWithCount> itemsets;
-        //itemsets = fp.getItemsets();
+        //itemsets = fp.getItemsetsWithSupportRatio();
 
         //printItemsets(itemsets);
 
@@ -69,7 +68,7 @@ public class StreamingFPGrowthTest {
 
         FPGrowth apriori = new FPGrowth();
 
-        List<ItemsetWithCount> apItemsets = apriori.getItemsets(allTxns, .2);
+        List<ItemsetWithCount> apItemsets = apriori.getItemsetsWithSupportRatio(allTxns, .2);
 
         System.out.println("MISSING SETS");
         Set<Set<Integer>> apis = apItemsets.stream().map(i -> i.getItems()).collect(Collectors.toSet());
@@ -112,7 +111,7 @@ public class StreamingFPGrowthTest {
 
         fp.buildTree(allTxns);
         List<ItemsetWithCount> itemsets;
-        //itemsets = fp.getItemsets();
+        //itemsets = fp.getItemsetsWithSupportRatio();
 
         //printItemsets(itemsets);
 


### PR DESCRIPTION
This set of changes fixes #53, #54, #55, and another bug where we weren't initializing the outlier transactions during `getCount` in the Batch step correctly.