### PR TITLE
Correct streaming prefix in bench.py

### DIFF
--- a/bench/execute_workflows.py
+++ b/bench/execute_workflows.py
@@ -25,10 +25,10 @@ default_args = {
   "macrobase.analysis.streaming.inlierItemSummarySize": 10000,
   "macrobase.analysis.streaming.outlierItemSummarySize": 10000,
   "macrobase.analysis.streaming.summaryUpdatePeriod": 100000,
-  "macrobase.analysis.period.modelRefreshPeriod": 100000,
+  "macrobase.analysis.streaming.modelUpdatePeriod": 100000,
 
   "macrobase.analysis.streaming.useRealTimePeriod": "false",
-  "macrobase.analysis.period.useTupleCountPeriod": "true",
+  "macrobase.analysis.streaming.useTupleCountPeriod": "true",
 
   "macrobase.analysis.streaming.warmupCount": 50000,
   "macrobase.analysis.streaming.decayRate": 0.01,

--- a/bench/streaming_template.conf
+++ b/bench/streaming_template.conf
@@ -23,7 +23,7 @@ macrobase.analysis.streaming.inlierItemSummarySize: %(macrobase.analysis.streami
 macrobase.analysis.streaming.outlierItemSummarySize: %(macrobase.analysis.streaming.outlierItemSummarySize)d
 
 macrobase.analysis.streaming.summaryUpdatePeriod: %(macrobase.analysis.streaming.summaryUpdatePeriod)d
-macrobase.analysis.streaming.modelRefreshPeriod: %(macrobase.analysis.streaming.modelRefreshPeriod)d
+macrobase.analysis.streaming.modelUpdatePeriod: %(macrobase.analysis.streaming.modelUpdatePeriod)d
 
 macrobase.analysis.streaming.useRealTimePeriod: %(macrobase.analysis.streaming.useRealTimePeriod)s
 macrobase.analysis.streaming.useTupleCountPeriod: %(macrobase.analysis.streaming.useTupleCountPeriod)s


### PR DESCRIPTION
a0658a121a894fb05b613b846684d2fc361b226d had the wrong prefix.