### PR TITLE
FPGrowth should traverse from bottom to top.

### DIFF
--- a/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/FPGrowth.java
@@ -33,7 +33,7 @@ public class FPGrowth {
         // used to calculate the order
         private Map<Integer, Double> frequentItemCounts = new HashMap<>();
 
-        // item order -- need canonical to break ties
+        // item order -- need canonical to break ties; 0 is smallest, N is largest
         private Map<Integer, Integer> frequentItemOrder = new HashMap<>();
 
         protected Map<Integer, FPTreeNode> nodeHeaders = new HashMap<>();

--- a/src/main/java/macrobase/analysis/summary/itemset/StreamingFPGrowth.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/StreamingFPGrowth.java
@@ -40,7 +40,7 @@ public class StreamingFPGrowth {
         // used to calculate the order
         private Map<Integer, Double> frequentItemCounts = new HashMap<>();
 
-        // item order -- need canonical to break ties
+        // item order -- need canonical to break ties; 0 is smallest, N is largest
         private Map<Integer, Integer> frequentItemOrder = new HashMap<>();
 
         protected Map<Integer, FPTreeNode> nodeHeaders = new HashMap<>();
@@ -264,7 +264,7 @@ public class StreamingFPGrowth {
 
             List<Integer> plist = Lists.newArrayList(pattern);
             // traverse bottom to top
-            plist.sort((i1, i2) -> frequentItemOrder.get(i2).compareTo(frequentItemOrder.get(i1)));
+            plist.sort((i1, i2) -> frequentItemOrder.get(i1).compareTo(frequentItemOrder.get(i2)));
 
             int count = 0;
             FPTreeNode pathHead = nodeHeaders.get(plist.get(0));
@@ -356,8 +356,8 @@ public class StreamingFPGrowth {
             // we have to materialize a canonical order so that items with equal counts
             // are consistently ordered when they are sorted during transaction insertion
             List<Map.Entry<Integer, Double>> sortedItemCounts = Lists.newArrayList(frequentItemCounts.entrySet());
-            sortedItemCounts.sort((i1, i2) -> frequentItemCounts.get(i2.getKey())
-                    .compareTo(frequentItemCounts.get(i1.getKey())));
+            sortedItemCounts.sort((i1, i2) -> frequentItemCounts.get(i1.getKey())
+                    .compareTo(frequentItemCounts.get(i2.getKey())));
             for (int i = 0; i < sortedItemCounts.size(); ++i) {
                 frequentItemOrder.put(sortedItemCounts.get(i).getKey(), i);
             }
@@ -386,11 +386,11 @@ public class StreamingFPGrowth {
 
         private void sortTransaction(List<Integer> txn, boolean isStreaming) {
             if (!isStreaming) {
-                txn.sort((i1, i2) -> frequentItemOrder.get(i1).compareTo(frequentItemOrder.get(i2)));
+                txn.sort((i1, i2) -> frequentItemOrder.get(i2).compareTo(frequentItemOrder.get(i1)));
             } else {
                 txn.sort((i1, i2) ->
-                                 frequentItemOrder.compute(i1, (k, v) -> v == null ? -i1 : v)
-                                         .compareTo(frequentItemOrder.compute(i2, (k, v) -> v == null ? -i2 : v)));
+                                 frequentItemOrder.compute(i2, (k, v) -> v == null ? -i2 : v)
+                                         .compareTo(frequentItemOrder.compute(i1, (k, v) -> v == null ? -i1 : v)));
             }
         }
 
@@ -717,6 +717,10 @@ public class StreamingFPGrowth {
     }
 
     public List<ItemsetWithCount> getCounts(List<ItemsetWithCount> targets) {
+        if(needsRestructure){
+            restructureTree(null);
+        }
+
         List<ItemsetWithCount> ret = new ArrayList<>(targets.size());
         for (ItemsetWithCount target : targets) {
             ret.add(new ItemsetWithCount(target.getItems(), fp.getSupport(target.getItems())));


### PR DESCRIPTION
This should have been addressed in e2efa185f827412297b5cfb4429d626b701272d2

It was fixed in FPGrowthStreaming but not FPGrowth...
https://github.com/stanford-futuredata/macrobase/commit/e2efa185f827412297b5cfb4429d626b701272d2#diff-17a5f28a45018f3282473cce06fb484fR267