### PR TITLE
ARIMA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,5 +180,10 @@
       <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.lucarosellini.rJava</groupId>
+      <artifactId>JRI</artifactId>
+      <version>0.9-7</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/macrobase/analysis/BaseAnalyzer.java
+++ b/src/main/java/macrobase/analysis/BaseAnalyzer.java
@@ -132,6 +132,9 @@ public class BaseAnalyzer {
             case MOVING_AVERAGE:
                 log.info("Using Moving Average detector.");
                 return new MovingAverage(conf);
+            case ARIMA:
+                log.info("Using ARIMA detector");
+                return new ARIMA(conf);
             default:
                 throw new RuntimeException("Unhandled detector class!" + detectorType);
         }

--- a/src/main/java/macrobase/analysis/outlier/ARIMA.java
+++ b/src/main/java/macrobase/analysis/outlier/ARIMA.java
@@ -1,0 +1,117 @@
+package macrobase.analysis.outlier;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.stream.DoubleStream;
+
+import org.rosuda.JRI.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import macrobase.conf.MacroBaseConf;
+import macrobase.conf.MacroBaseDefaults;
+import macrobase.datamodel.Datum;
+
+/**
+ * ARIMA time series predictions. Note that this implementation doesn't support
+ * points that are not evenly distributed, and thus the time for each datum is
+ * simply ignored and we assume that they are evenly distributed.
+ * 
+ * We use R to make these predictions, so you need to have R and rJava
+ * installed. In addition, you need to install the R package 'forecast' (using
+ * `install.packages('forecast', dependencies = TRUE)`), and set the R_HOME
+ * environment variable appropriately (you can get its value by running
+ * `R.home()` inside R).
+ */
+public class ARIMA extends TimeSeriesOutlierDetector {
+    private static final Logger log = LoggerFactory.getLogger(ARIMA.class);
+    private Queue<Double> window = new LinkedList<Double>();
+    private Double latestScore;
+    private Queue<Double> predictions;
+    private int datumCounter;
+    private static Rengine re;
+
+    public ARIMA(MacroBaseConf conf) {
+        super(conf);
+
+        if (re == null) {
+            re = new Rengine(new String[] { "--vanilla" }, false, null);
+        }
+        if (!re.waitForR()) {
+            throw new RuntimeException("Unable to load R");
+        }
+        re.eval("library(forecast)");
+
+        String logFile = conf.getString(MacroBaseConf.R_LOG_FILE,
+                MacroBaseDefaults.R_LOG_FILE);
+        if (logFile != null) {
+            re.eval("log <- file('" + logFile + "')");
+            re.eval("sink(log, append=TRUE)");
+            re.eval("sink(log, append=TRUE, type='message')");
+        }
+    }
+
+    @Override
+    public void train(List<Datum> data) {
+        super.train(data);
+        assert (data.get(0).getMetrics().getDimension() == 1);
+    }
+
+    @Override
+    public void addToWindow(Datum datum) {
+        double value = datum.getMetrics().getEntry(0);
+        window.add(value);
+
+        if (predictions != null) {
+            // TODO we could try to be more intelligent about scoring here -
+            // currentPrediction is the mean, but the probabilities aren't
+            // necessarily distributed evenly around the mean.
+            double prediction = predictions.remove();
+            latestScore = Math.abs((value - prediction) / prediction);
+        }
+
+        if (datumCounter < (tupleWindowSize - 1)) {
+            datumCounter++;
+        } else if (predictions == null || predictions.isEmpty()) {
+            // We need to add new predictions if the current size is 1
+            trainWindow();
+        }
+    }
+
+    @Override
+    public void removeLastFromWindow() {
+        window.remove();
+    }
+
+    private void trainWindow() {
+        log.debug("Running ARIMA trainWindow");
+        if (predictions == null) {
+            predictions = new LinkedList<Double>();
+        }
+
+        double[] windowArray = window.stream().mapToDouble(Double::doubleValue)
+                .toArray();
+        re.assign("data", windowArray);
+        // TODO reuse old models
+        re.eval("fit <- auto.arima(data)");
+        // TODO add config option for how far we should predict before
+        // retraining - allow configuring how often we update parameters, and
+        // also how often we update model order.
+        double[] result = re.eval("forecast(fit, h=" + tupleWindowSize + ")$mean")
+                .asDoubleArray();
+        Double[] boxedResult = DoubleStream.of(result).boxed()
+                .toArray(size -> new Double[size]);
+        Collections.addAll(predictions, boxedResult);
+    }
+
+    @Override
+    public double scoreWindow() {
+        if (latestScore == null) {
+            return 0;
+        } else {
+            return latestScore;
+        }
+    }
+}

--- a/src/main/java/macrobase/analysis/outlier/TimeSeriesOutlierDetector.java
+++ b/src/main/java/macrobase/analysis/outlier/TimeSeriesOutlierDetector.java
@@ -20,7 +20,9 @@ public abstract class TimeSeriesOutlierDetector extends OutlierDetector {
 
     public abstract void removeLastFromWindow();
 
-    // Score current window.
+    /**
+     * Use the current window to build a model and then score the latest datum.
+     */
     public abstract double scoreWindow();
 
     @Override

--- a/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -53,6 +53,7 @@ public class MacroBaseConf extends Configuration {
     public static final String KDTREE_LEAF_CAPACITY = "macrobase.analysis.treeKde.leafCapacity";
     public static final String TREE_KDE_ACCURACY = "macrobase.analysis.treeKde.accuracy";
 
+    public static final String R_LOG_FILE = "macrobase.analysis.r.logfile";
     public static final String STORE_ANALYSIS_RESULTS = "macrobase.analysis.results.store";
 
     public static final String DATA_TRANSFORM_TYPE = "macrobase.loader.transformType";
@@ -87,7 +88,8 @@ public class MacroBaseConf extends Configuration {
         KDE,
         BINNED_KDE,
         TREE_KDE,
-        MOVING_AVERAGE
+        MOVING_AVERAGE,
+        ARIMA
     }
 
     public enum DataLoaderType {

--- a/src/main/java/macrobase/conf/MacroBaseDefaults.java
+++ b/src/main/java/macrobase/conf/MacroBaseDefaults.java
@@ -52,6 +52,7 @@ public class MacroBaseDefaults {
     public static final Integer KDTREE_LEAF_CAPACITY = 2;
     public static final Double TREE_KDE_ACCURACY = 1e-5;
 
+    public static final String R_LOG_FILE = null;
     // Analysis results
     public static final String STORE_ANALYSIS_RESULTS = null;
 

--- a/src/test/java/macrobase/analysis/outlier/ARIMATest.java
+++ b/src/test/java/macrobase/analysis/outlier/ARIMATest.java
@@ -1,0 +1,86 @@
+package macrobase.analysis.outlier;
+
+import macrobase.conf.MacroBaseConf;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ARIMATest {
+    @Test
+    public void constantTest() {
+        int windowSize = 10;
+        MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, windowSize);
+        ARIMA a = new ARIMA(conf);
+        for (int i = 0; i < windowSize; i++) {
+            a.score(TestOutlierUtils.createTimeDatum(i, 1));
+        }
+        
+        assertEquals(0,
+            a.score(TestOutlierUtils.createTimeDatum(windowSize + 1, 1)),
+            1e-5);
+        assertEquals(1,
+            a.score(TestOutlierUtils.createTimeDatum(windowSize + 2, 2)),
+            1e-5);
+    }
+    
+    @Test
+    public void linearTest() {
+        int windowSize = 10;
+        MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, windowSize);
+        ARIMA a = new ARIMA(conf);
+        for (int i = 0; i < windowSize; i++) {
+            a.score(TestOutlierUtils.createTimeDatum(i, i));
+        }
+        
+        assertEquals(0,
+            a.score(TestOutlierUtils.createTimeDatum(windowSize, windowSize)),
+            1e-5);
+        assertEquals(0,
+            a.score(TestOutlierUtils.createTimeDatum(windowSize + 1, windowSize + 1)),
+            1e-5);
+        assertEquals(1.0 / (windowSize + 2),
+            a.score(TestOutlierUtils.createTimeDatum(windowSize + 2, windowSize + 1)),
+            1e-5);
+    }
+    
+    @Test
+    public void simpleTest() {
+        MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, 6);
+        ARIMA a = new ARIMA(conf);
+        a.score(TestOutlierUtils.createTimeDatum(0, 1.5));
+        a.score(TestOutlierUtils.createTimeDatum(1, 4.5));
+        a.score(TestOutlierUtils.createTimeDatum(0, 5.0));
+        a.score(TestOutlierUtils.createTimeDatum(1, 6.5));
+        a.score(TestOutlierUtils.createTimeDatum(0, 8.5));
+        a.score(TestOutlierUtils.createTimeDatum(0, 12.0));
+        
+        assertEquals(0.078,
+            a.score(TestOutlierUtils.createTimeDatum(1, 13)),
+            1e-3);
+        assertEquals(0.198,
+            a.score(TestOutlierUtils.createTimeDatum(1, 13)),
+            1e-3);
+    }
+    
+    @Test
+    public void windowTest() {
+        int windowSize = 5;
+        MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, windowSize);
+        ARIMA a = new ARIMA(conf);
+        for (int i = 0; i < windowSize; i++) {
+            a.score(TestOutlierUtils.createTimeDatum(i, 1));
+        }
+        
+        // Now model will predict 1 for the next windowSize datum.
+        for (int i = 0; i < windowSize; i++) {
+            assertEquals(9,
+                a.score(TestOutlierUtils.createTimeDatum(windowSize + i, 10)),
+                1e-5);
+        }
+
+        // Check that after window slide and retrain, model predicts 10.
+        assertEquals(0,
+            a.score(TestOutlierUtils.createTimeDatum(windowSize * 2, 10)),
+            1e-5);
+    }
+}

--- a/src/test/java/macrobase/analysis/outlier/ARIMATest.java
+++ b/src/test/java/macrobase/analysis/outlier/ARIMATest.java
@@ -2,10 +2,16 @@ package macrobase.analysis.outlier;
 
 import macrobase.conf.MacroBaseConf;
 
+import org.junit.Ignore;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
-public class ARIMATest {
+/**
+ * These tests are ignored by default so that people running the test suite
+ * locally aren't required to have R and rJava installed.
+ */
+@Ignore public class ARIMATest {
     @Test
     public void constantTest() {
         int windowSize = 10;

--- a/src/test/java/macrobase/analysis/outlier/MovingAverageTest.java
+++ b/src/test/java/macrobase/analysis/outlier/MovingAverageTest.java
@@ -2,39 +2,27 @@ package macrobase.analysis.outlier;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-
 import macrobase.conf.MacroBaseConf;
-import macrobase.datamodel.TimeDatum;
 
-import org.apache.commons.math3.linear.ArrayRealVector;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 public class MovingAverageTest {
     @Test
     public void simpleTest() {
         MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, 3);
         MovingAverage ma = new MovingAverage(conf);
-        assertEquals(0, ma.score(createDatum(0, 1)), 0);
-        assertEquals(1/3.0, ma.score(createDatum(1, 2)), 1e-5); // Average = 1.5
-        assertEquals(1/2.0, ma.score(createDatum(2, 3)), 1e-5); // Average = 2
-        assertEquals(1/3.0, ma.score(createDatum(3, 4)), 1e-5); // Average = 3
-    }
-    
-    private TimeDatum createDatum(int time, double d) {
-        double[] sample = new double[1];
-        sample[0] = d;
-        return new TimeDatum(time, new ArrayList<>(), new ArrayRealVector(sample));
+        assertEquals(0, ma.score(TestOutlierUtils.createTimeDatum(0, 1)), 0);
+        assertEquals(1/3.0, ma.score(TestOutlierUtils.createTimeDatum(1, 2)), 1e-5); // Average = 1.5
+        assertEquals(1/2.0, ma.score(TestOutlierUtils.createTimeDatum(2, 3)), 1e-5); // Average = 2
+        assertEquals(1/3.0, ma.score(TestOutlierUtils.createTimeDatum(3, 4)), 1e-5); // Average = 3
     }
     
     @Test
     public void weightTest() {
         MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TUPLE_WINDOW, 3);
         MovingAverage ma = new MovingAverage(conf);
-        assertEquals(0, ma.score(createDatum(0, 1)), 0);
-        assertEquals(1/3.0, ma.score(createDatum(1, 2)), 0); // Average = 1.5
-        assertEquals(1/3.0, ma.score(createDatum(3, 3)), 0); // This point has twice the weight due to its time, so average = 2.25
+        assertEquals(0, ma.score(TestOutlierUtils.createTimeDatum(0, 1)), 0);
+        assertEquals(1/3.0, ma.score(TestOutlierUtils.createTimeDatum(1, 2)), 0); // Average = 1.5
+        assertEquals(1/3.0, ma.score(TestOutlierUtils.createTimeDatum(3, 3)), 0); // This point has twice the weight due to its time, so average = 2.25
     }
 }

--- a/src/test/java/macrobase/analysis/outlier/TestOutlierUtils.java
+++ b/src/test/java/macrobase/analysis/outlier/TestOutlierUtils.java
@@ -1,0 +1,15 @@
+package macrobase.analysis.outlier;
+
+import java.util.ArrayList;
+
+import macrobase.datamodel.TimeDatum;
+
+import org.apache.commons.math3.linear.ArrayRealVector;
+
+public class TestOutlierUtils {
+    public static TimeDatum createTimeDatum(int time, double d) {
+        double[] sample = new double[1];
+        sample[0] = d;
+        return new TimeDatum(time, new ArrayList<>(), new ArrayRealVector(sample));
+    }
+}


### PR DESCRIPTION
Implementation of ARIMA that calls out to R. I also have the dumb version of streaming MAD that recomputes on every window change, but given that we’re going to change the streaming API I don’t think that’s worth merging for now.

Note that there is also a [Spark ARIMA implementation](https://github.com/sryza/spark-timeseries/blob/master/src/main/scala/com/cloudera/sparkts/models/ARIMA.scala), which may be useful if we want a pure Java implementation, but it doesn't support many of the R version's features (e.g. seasonality, Kalman filtering, trying to automatically deduce p,d,q).