### PR TITLE
Allow using DensityEstimators as Classifiers (instead of Transforms)

### DIFF
--- a/script/py_analysis/plot_density_1D.py
+++ b/script/py_analysis/plot_density_1D.py
@@ -1,0 +1,34 @@
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+import argparse
+
+
+def parse_args(*argument_list):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('dump_density_grid_file',
+      help=('File that was dumped using'  # noqa
+            '"macrobase.diagnostic.dumpDensityGridFile" option in macrobase'))
+  parser.add_argument('--dump-score-file', help='File that was dumped using'
+      '"macrobase.diagnostic.dumpScoreFile" option in macrobase')  # noqa
+  args = parser.parse_args(*argument_list)
+  return args
+
+
+def load_json_dump(filename):
+  with open(filename) as infile:
+    data = json.load(infile)
+  return zip(*[(point['metrics']['data'], point['density'])
+               for point in data])
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  X, Y = load_json_dump(args.dump_density_grid_file)
+
+  XX, YY = load_json_dump(args.dump_score_file)
+  _, bins, _ = plt.hist(XX)
+  w = bins[1] - bins[0]
+  Y = np.array(Y) * w * len(XX)
+  plt.plot(X, Y)
+  plt.show()

--- a/src/main/java/macrobase/analysis/classify/DensityBatchPercentileClassifier.java
+++ b/src/main/java/macrobase/analysis/classify/DensityBatchPercentileClassifier.java
@@ -1,0 +1,58 @@
+package macrobase.analysis.classify;
+
+import com.google.common.collect.Lists;
+import macrobase.analysis.result.OutlierClassificationResult;
+import macrobase.analysis.stats.DensityEstimater;
+import macrobase.conf.ConfigurationException;
+import macrobase.conf.MacroBaseConf;
+import macrobase.conf.MacroBaseDefaults;
+import macrobase.datamodel.Datum;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class DensityBatchPercentileClassifier extends OutlierClassifier {
+    Iterator<OutlierClassificationResult> resultIterator;
+    DensityEstimater densityEstimater;
+
+    final double targetPercentile;
+
+    public DensityBatchPercentileClassifier(MacroBaseConf conf, Iterator<Datum> input) throws ConfigurationException {
+        this(conf, input, conf.getDouble(MacroBaseConf.TARGET_PERCENTILE, MacroBaseDefaults.TARGET_PERCENTILE));
+    }
+
+    public DensityBatchPercentileClassifier(MacroBaseConf conf, Iterator<Datum> input, double percentile) throws ConfigurationException {
+        super(conf, input);
+        this.targetPercentile = percentile;
+        this.densityEstimater = conf.constructDensityEstimator();
+    }
+
+    @Override
+    public OutlierClassificationResult next() {
+        if (resultIterator == null) {
+            List<Datum> toClassify = Lists.newArrayList(input);
+            densityEstimater.train(toClassify);
+            for (Datum d : toClassify) {
+                d.setDensity(densityEstimater.density(d));
+            }
+
+            // Use reverse sort because we want points with low density (not high distance, e.g. ZScore)
+            toClassify.sort((a, b) -> Double.compare(b.getDensity(), b.getDensity()));
+
+            int splitPoint = (int) (toClassify.size() * targetPercentile);
+            List<OutlierClassificationResult> classificationResults = new ArrayList<>(toClassify.size());
+            for (int i = 0; i < toClassify.size(); ++i) {
+                Datum d = toClassify.get(i);
+                classificationResults.add(new OutlierClassificationResult(d, i >= splitPoint));
+            }
+            resultIterator = classificationResults.iterator();
+        }
+        return resultIterator.next();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return input.hasNext() || (resultIterator != null && resultIterator.hasNext());
+    }
+}

--- a/src/main/java/macrobase/analysis/classify/DensityBatchPercentileClassifier.java
+++ b/src/main/java/macrobase/analysis/classify/DensityBatchPercentileClassifier.java
@@ -7,6 +7,9 @@ import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.conf.MacroBaseDefaults;
 import macrobase.datamodel.Datum;
+import macrobase.diagnostics.DensityDumper;
+import macrobase.diagnostics.JsonUtils;
+import macrobase.util.AlgebraUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -15,6 +18,9 @@ import java.util.List;
 public class DensityBatchPercentileClassifier extends OutlierClassifier {
     Iterator<OutlierClassificationResult> resultIterator;
     DensityEstimater densityEstimater;
+    String densityGridFile;
+    String scoredDataFile;
+    Integer numGridPointsPerDimension;
 
     final double targetPercentile;
 
@@ -26,6 +32,9 @@ public class DensityBatchPercentileClassifier extends OutlierClassifier {
         super(conf, input);
         this.targetPercentile = percentile;
         this.densityEstimater = conf.constructDensityEstimator();
+        densityGridFile = conf.getString(MacroBaseConf.DUMP_DENSITY_GRID_TO, MacroBaseDefaults.DUMP_DENSITY_GRID_TO);
+        scoredDataFile = conf.getString(MacroBaseConf.SCORED_DATA_FILE, MacroBaseDefaults.SCORED_DATA_FILE);
+        numGridPointsPerDimension = conf.getInt(MacroBaseConf.NUM_DENSITY_GRID_POINTS_PER_DIMENSION, MacroBaseDefaults.NUM_DENSITY_GRID_POINTS_PER_DIMENSION);
     }
 
     @Override
@@ -35,6 +44,13 @@ public class DensityBatchPercentileClassifier extends OutlierClassifier {
             densityEstimater.train(toClassify);
             for (Datum d : toClassify) {
                 d.setDensity(densityEstimater.density(d));
+            }
+
+            if (scoredDataFile != null) {
+                JsonUtils.tryToDumpAsJson(toClassify, scoredDataFile);
+            }
+            if (densityGridFile != null) {
+                DensityDumper.tryToDumpScoredGrid(densityEstimater, AlgebraUtils.getBoundingBox(toClassify), numGridPointsPerDimension, densityGridFile);
             }
 
             // Use reverse sort because we want points with low density (not high distance, e.g. ZScore)

--- a/src/main/java/macrobase/analysis/pipeline/AbstractPipeline.java
+++ b/src/main/java/macrobase/analysis/pipeline/AbstractPipeline.java
@@ -1,15 +1,11 @@
 package macrobase.analysis.pipeline;
 
-import macrobase.analysis.classify.OutlierClassifier;
 import macrobase.analysis.result.AnalysisResult;
-import macrobase.analysis.summary.Summarizer;
 import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.conf.MacroBaseConf.DataIngesterType;
 import macrobase.conf.MacroBaseConf.TransformType;
 import macrobase.conf.MacroBaseDefaults;
-import macrobase.ingest.DataIngester;
-import macrobase.analysis.transform.FeatureTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +32,6 @@ public abstract class AbstractPipeline implements Iterator<AnalysisResult> {
     protected final List<String> lowMetrics;
     protected final MacroBaseConf conf;
     protected final String queryName;
-    protected final String storeAnalysisResults;
     protected final boolean contextualEnabled;
 
     public AbstractPipeline(MacroBaseConf conf) throws ConfigurationException {
@@ -58,8 +53,6 @@ public abstract class AbstractPipeline implements Iterator<AnalysisResult> {
         attributes = conf.getStringList(MacroBaseConf.ATTRIBUTES);
         lowMetrics = conf.getStringList(MacroBaseConf.LOW_METRICS);
         highMetrics = conf.getStringList(MacroBaseConf.HIGH_METRICS);
-
-        storeAnalysisResults = conf.getString(MacroBaseConf.STORE_ANALYSIS_RESULTS, MacroBaseDefaults.STORE_ANALYSIS_RESULTS);
 
         contextualEnabled = conf.getBoolean(MacroBaseConf.CONTEXTUAL_ENABLED, MacroBaseDefaults.CONTEXTUAL_ENABLED);
         contextualDiscreteAttributes = conf.getStringList(MacroBaseConf.CONTEXTUAL_DISCRETE_ATTRIBUTES,MacroBaseDefaults.CONTEXTUAL_DISCRETE_ATTRIBUTES);

--- a/src/main/java/macrobase/analysis/pipeline/BasicBatchedPipeline.java
+++ b/src/main/java/macrobase/analysis/pipeline/BasicBatchedPipeline.java
@@ -1,7 +1,6 @@
 package macrobase.analysis.pipeline;
 
 import com.google.common.collect.Lists;
-import macrobase.analysis.classify.BatchingPercentileClassifier;
 import macrobase.analysis.classify.OutlierClassifier;
 import macrobase.analysis.contextualoutlier.Context;
 import macrobase.analysis.contextualoutlier.ContextualOutlierDetector;
@@ -9,17 +8,17 @@ import macrobase.analysis.result.AnalysisResult;
 import macrobase.analysis.stats.BatchTrainScore;
 import macrobase.analysis.summary.BatchSummarizer;
 import macrobase.analysis.summary.Summary;
+import macrobase.analysis.transform.BatchScoreFeatureTransform;
 import macrobase.analysis.transform.FeatureTransform;
 import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.datamodel.Datum;
 import macrobase.ingest.DataIngester;
 import macrobase.ingest.TimedBatchIngest;
-import macrobase.analysis.transform.BatchScoreFeatureTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +58,7 @@ public class BasicBatchedPipeline extends OneShotPipeline {
         DataIngester ingester = conf.constructIngester();
         TimedBatchIngest batchIngest = new TimedBatchIngest(ingester);
         FeatureTransform featureTransform = new BatchScoreFeatureTransform(conf, batchIngest, conf.getTransformType());
-        OutlierClassifier outlierClassifier = new BatchingPercentileClassifier(conf, featureTransform);
+        OutlierClassifier outlierClassifier = conf.constructOutlierClassifier(featureTransform);
         BatchSummarizer summarizer = new BatchSummarizer(conf, outlierClassifier);
 
         // TODO: this should be a new pipeline

--- a/src/main/java/macrobase/analysis/stats/DensityEstimater.java
+++ b/src/main/java/macrobase/analysis/stats/DensityEstimater.java
@@ -1,0 +1,11 @@
+package macrobase.analysis.stats;
+
+import macrobase.datamodel.Datum;
+
+import java.util.List;
+
+public interface DensityEstimater {
+    double density(Datum datum);
+
+    void train(List<Datum> data);
+}

--- a/src/main/java/macrobase/analysis/stats/mixture/VariationalDPMG.java
+++ b/src/main/java/macrobase/analysis/stats/mixture/VariationalDPMG.java
@@ -1,6 +1,7 @@
 package macrobase.analysis.stats.mixture;
 
 import macrobase.analysis.stats.BatchMixtureModel;
+import macrobase.analysis.stats.DensityEstimater;
 import macrobase.analysis.stats.distribution.MultivariateTDistribution;
 import macrobase.conf.MacroBaseConf;
 import macrobase.conf.MacroBaseDefaults;
@@ -17,7 +18,7 @@ import java.util.List;
 /**
  * Variational Dirichlet Process Mixture of Gaussians.
  */
-public class VariationalDPMG extends BatchMixtureModel {
+public class VariationalDPMG extends BatchMixtureModel implements DensityEstimater {
     private static final Logger log = LoggerFactory.getLogger(VariationalDPMG.class);
     private final int maxIterationsToConverge;
 
@@ -88,6 +89,16 @@ public class VariationalDPMG extends BatchMixtureModel {
         baseLocation = new ArrayRealVector(midpoints);
         inverseBaseOmega = MatrixUtils.createRealIdentityMatrix(dimension);
 
+    }
+
+    @Override
+    public double density(Datum datum) {
+        double density = 0;
+        double[] stickLengths = getClusterWeights();
+        for (int i=0; i < predictiveDistributions.size(); i++){
+            density += stickLengths[i] * predictiveDistributions.get(i).density(datum.getMetrics());
+        }
+        return density;
     }
 
     @Override
@@ -249,12 +260,7 @@ public class VariationalDPMG extends BatchMixtureModel {
 
     @Override
     public double score(Datum datum) {
-        double density = 0;
-        double[] stickLengths = getClusterWeights();
-        for (int i=0; i < predictiveDistributions.size(); i++){
-            density += stickLengths[i] * predictiveDistributions.get(i).density(datum.getMetrics());
-        }
-        return density;
+        return density(datum);
     }
 
     @Override

--- a/src/main/java/macrobase/analysis/transform/BatchScoreFeatureTransform.java
+++ b/src/main/java/macrobase/analysis/transform/BatchScoreFeatureTransform.java
@@ -12,11 +12,17 @@ import java.util.List;
 public class BatchScoreFeatureTransform extends BatchTransform {
     protected BatchTrainScore batchTrainScore;
     protected MacroBaseConf conf;
+    protected boolean identityTransform;
 
     public BatchScoreFeatureTransform(MacroBaseConf conf, Iterator<Datum> input, MacroBaseConf.TransformType transformType)
             throws ConfigurationException {
         super(input);
-        this.batchTrainScore = conf.constructTransform(transformType);
+        if (transformType == MacroBaseConf.TransformType.IDENTITY) {
+            identityTransform = true;
+        } else {
+            this.batchTrainScore = conf.constructTransform(transformType);
+            identityTransform = false;
+        }
         this.conf = conf;
     }
 
@@ -26,6 +32,9 @@ public class BatchScoreFeatureTransform extends BatchTransform {
 
     @Override
     protected List<Datum> transform(List<Datum> data) {
+        if (identityTransform) {
+            return data;
+        }
         batchTrainScore.train(data);
         List<Datum> results = new ArrayList<>(data.size());
         for(Datum d : data) {

--- a/src/main/java/macrobase/analysis/transform/BatchScoreFeatureTransform.java
+++ b/src/main/java/macrobase/analysis/transform/BatchScoreFeatureTransform.java
@@ -26,10 +26,6 @@ public class BatchScoreFeatureTransform extends BatchTransform {
         this.conf = conf;
     }
 
-    public BatchScoreFeatureTransform(MacroBaseConf conf, Iterator<Datum> input) throws ConfigurationException {
-        this(conf, input, conf.getTransformType());
-    }
-
     @Override
     protected List<Datum> transform(List<Datum> data) {
         if (identityTransform) {

--- a/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -94,7 +94,9 @@ public class MacroBaseConf extends Configuration {
     public static final String CONTEXTUAL_NUMINTERVALS = "macrobase.analysis.contextual.numIntervals";
     public static final String OUTLIER_STATIC_THRESHOLD = "macrobase.analysis.classify.outlierStaticThreshold";
 
-    public static final String SCORE_DUMP_FILE_CONFIG_PARAM = "macrobase.diagnostic.dumpScoreFile";
+    public static final String SCORED_DATA_FILE = "macrobase.diagnostic.dumpScoreFile";
+    public static final String DUMP_DENSITY_GRID_TO = "macrobase.diagnostic.dumpDensityGridFile";
+    public static final String NUM_DENSITY_GRID_POINTS_PER_DIMENSION = "macrobase.diagnostic.densityGridPointsPerDimension";
 
     private final DatumEncoder datumEncoder;
 

--- a/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -2,10 +2,14 @@ package macrobase.conf;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.dropwizard.Configuration;
+import macrobase.analysis.classify.BatchingPercentileClassifier;
+import macrobase.analysis.classify.DensityBatchPercentileClassifier;
+import macrobase.analysis.classify.OutlierClassifier;
 import macrobase.analysis.stats.*;
 import macrobase.analysis.stats.mixture.GaussianMixtureModel;
 import macrobase.analysis.stats.mixture.VariationalDPMG;
 import macrobase.analysis.stats.mixture.VariationalGMM;
+import macrobase.analysis.transform.FeatureTransform;
 import macrobase.ingest.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +42,7 @@ public class MacroBaseConf extends Configuration {
     public static final String MODEL_UPDATE_PERIOD = "macrobase.analysis.streaming.modelUpdatePeriod";
     public static final String OUTLIER_ITEM_SUMMARY_SIZE = "macrobase.analysis.streaming.outlierSummarySize";
     public static final String INLIER_ITEM_SUMMARY_SIZE = "macrobase.analysis.streaming.inlierItemSummarySize";
-    
+
     public static final String TUPLE_WINDOW = "macrobase.analysis.timeseries.tupleWindow";
 
     public static final String MCD_ALPHA = "macrobase.analysis.mcd.alpha";
@@ -62,7 +66,9 @@ public class MacroBaseConf extends Configuration {
     public static final String TREE_KDE_ACCURACY = "macrobase.analysis.treeKde.accuracy";
 
     public static final String R_LOG_FILE = "macrobase.analysis.r.logfile";
-    public static final String STORE_ANALYSIS_RESULTS = "macrobase.analysis.results.store";
+
+    public static final String CLASSIFIER_TYPE = "macrobase.classify.classifierType";
+    public static final String DENSITY_ESTIMATER_TYPE = "macrobase.classify.densityEstimaterType";
 
     public static final String DATA_LOADER_TYPE = "macrobase.loader.loaderType";
     public static final String TIME_COLUMN = "macrobase.loader.timeColumn";
@@ -80,7 +86,7 @@ public class MacroBaseConf extends Configuration {
 
     public static final String CSV_INPUT_FILE = "macrobase.loader.csv.file";
     public static final String CSV_COMPRESSION = "macrobase.loader.csv.compression";
-    
+
     public static final String CONTEXTUAL_ENABLED = "macrobase.analysis.contextual.enabled";
     public static final String CONTEXTUAL_DISCRETE_ATTRIBUTES = "macrobase.analysis.contextual.discreteAttributes";
     public static final String CONTEXTUAL_DOUBLE_ATTRIBUTES = "macrobase.analysis.contextual.doubleAttributes";
@@ -89,6 +95,7 @@ public class MacroBaseConf extends Configuration {
     public static final String OUTLIER_STATIC_THRESHOLD = "macrobase.analysis.classify.outlierStaticThreshold";
 
     public static final String SCORE_DUMP_FILE_CONFIG_PARAM = "macrobase.diagnostic.dumpScoreFile";
+
     private final DatumEncoder datumEncoder;
 
     public MacroBaseConf() {
@@ -113,9 +120,45 @@ public class MacroBaseConf extends Configuration {
         return datumEncoder;
     }
 
+    public OutlierClassifier constructOutlierClassifier(FeatureTransform featureTransform) throws ConfigurationException {
+        ClassifierType classifierType = getClassifierType();
+        switch (classifierType) {
+            case NORM_PERCENTILE:
+                return new BatchingPercentileClassifier(this, featureTransform);
+            case DENSITY_PERCENTILE:
+                return new DensityBatchPercentileClassifier(this, featureTransform);
+            default:
+                throw new ConfigurationException(String.format("Unknown classifier type: %s", classifierType));
+        }
+    }
+
+    public DensityEstimater constructDensityEstimator() throws ConfigurationException {
+        DensityEstimaterType densityEstimaterType = getDensityEstimatorType();
+        switch (densityEstimaterType) {
+            case GMM:
+                log.info("Using finite mixture of Gaussians (DP Bayesian algorithm) transform.");
+                return new VariationalGMM(this);
+            case DPGMM:
+                log.info("Using infinite mixture of Gaussians (DP Bayesian algorithm) transform.");
+                return new VariationalDPMG(this);
+            default:
+                throw new ConfigurationException(String.format("Unknown DensityEstimater type: %s", getDensityEstimatorType()));
+        }
+    }
+
+    public enum ClassifierType {
+        NORM_PERCENTILE,
+        DENSITY_PERCENTILE
+    }
+
     public enum PeriodType {
         TUPLE_BASED,
         TIME_BASED
+    }
+
+    public enum DensityEstimaterType {
+        DPGMM,
+        GMM
     }
 
     public enum TransformType {
@@ -132,19 +175,20 @@ public class MacroBaseConf extends Configuration {
         GAUSSIAN_MIXTURE_EM,
         VARIATIONAL_GMM,
         VARIATIONAL_DPGM,
+        IDENTITY,
     }
 
     public Random getRandom() {
         Long seed = getLong(RANDOM_SEED, null);
-        if(seed != null) {
+        if (seed != null) {
             return new Random(seed);
         } else {
             return new Random();
         }
     }
 
-    public BatchTrainScore constructTransform (TransformType transformType)
-            throws ConfigurationException{
+    public BatchTrainScore constructTransform(TransformType transformType)
+            throws ConfigurationException {
         switch (transformType) {
             case MAD_OR_MCD:
                 int metricsDimensions = this.getStringList(LOW_METRICS).size() + this.getStringList(HIGH_METRICS).size();
@@ -198,7 +242,7 @@ public class MacroBaseConf extends Configuration {
     public enum DataIngesterType {
         CSV_LOADER,
         POSTGRES_LOADER,
-        CACHING_POSTGRES_LOADER
+        CLASSIFIER_TYPE, CACHING_POSTGRES_LOADER
     }
 
 
@@ -299,6 +343,20 @@ public class MacroBaseConf extends Configuration {
         return defaultValue;
     }
 
+    public ClassifierType getClassifierType() throws ConfigurationException {
+        if (!_conf.containsKey(CLASSIFIER_TYPE)) {
+            return MacroBaseDefaults.CLASSIFIER_TYPE;
+        }
+        return ClassifierType.valueOf(_conf.get(CLASSIFIER_TYPE));
+    }
+
+    public DensityEstimaterType getDensityEstimatorType() {
+        if (!_conf.containsKey(DENSITY_ESTIMATER_TYPE)) {
+            return MacroBaseDefaults.DENSITY_ESTIMATER_TYPE;
+        }
+        return DensityEstimaterType.valueOf(_conf.get(DENSITY_ESTIMATER_TYPE));
+    }
+
     public DataIngesterType getDataLoaderType() throws ConfigurationException {
         if (!_conf.containsKey(DATA_LOADER_TYPE)) {
             return MacroBaseDefaults.DATA_LOADER_TYPE;
@@ -350,15 +408,14 @@ public class MacroBaseConf extends Configuration {
     }
 
     private void sanityCheckBase() throws ConfigurationException {
-        if(getBoolean(USE_PERCENTILE, false) && getBoolean(USE_ZSCORE, false)) {
+        if (getBoolean(USE_PERCENTILE, false) && getBoolean(USE_ZSCORE, false)) {
             throw new ConfigurationException(String.format("Can only select one of %s or %s",
-                                                           USE_PERCENTILE,
-                                                           USE_ZSCORE));
-        }
-        else if(!(getBoolean(USE_PERCENTILE, false) || getBoolean(USE_ZSCORE, false))) {
+                    USE_PERCENTILE,
+                    USE_ZSCORE));
+        } else if (!(getBoolean(USE_PERCENTILE, false) || getBoolean(USE_ZSCORE, false))) {
             throw new ConfigurationException(String.format("Must select one of %s or %s",
-                                                           USE_PERCENTILE,
-                                                           USE_ZSCORE));
+                    USE_PERCENTILE,
+                    USE_ZSCORE));
         }
     }
 
@@ -376,4 +433,5 @@ public class MacroBaseConf extends Configuration {
                 .filter(e -> e.startsWith("macrobase"))
                 .forEach(e -> set(e, System.getProperty(e)));
     }
+
 }

--- a/src/main/java/macrobase/conf/MacroBaseDefaults.java
+++ b/src/main/java/macrobase/conf/MacroBaseDefaults.java
@@ -29,7 +29,7 @@ public class MacroBaseDefaults {
     public static final Double MODEL_UPDATE_PERIOD = 100000.;
     public static final Integer OUTLIER_ITEM_SUMMARY_SIZE = 100000;
     public static final Integer INLIER_ITEM_SUMMARY_SIZE = 100000;
-    
+
     // timeseries defaults
     public static final Integer TUPLE_WINDOW = 100;
 
@@ -61,7 +61,7 @@ public class MacroBaseDefaults {
     public static final String DB_PASSWORD = "";
     public static final String DB_NAME = "postgres";
     public static final String DB_URL = "localhost";
-    
+
     public static final Boolean CONTEXTUAL_ENABLED = false;
     public static final Double CONTEXTUAL_DENSECONTEXTTAU = 0.5;
     public static final Integer CONTEXTUAL_NUMINTERVALS = 10;
@@ -75,4 +75,7 @@ public class MacroBaseDefaults {
     public static final Integer MIXTURE_MAX_ITERATIONS_TO_CONVERGE = 100;
     public static final MacroBaseConf.ClassifierType CLASSIFIER_TYPE = MacroBaseConf.ClassifierType.NORM_PERCENTILE;
     public static final MacroBaseConf.DensityEstimaterType DENSITY_ESTIMATER_TYPE = MacroBaseConf.DensityEstimaterType.DPGMM;
+    public static final String SCORED_DATA_FILE = null;
+    public static final String DUMP_DENSITY_GRID_TO = null;
+    public static final Integer NUM_DENSITY_GRID_POINTS_PER_DIMENSION = 1000;
 }

--- a/src/main/java/macrobase/conf/MacroBaseDefaults.java
+++ b/src/main/java/macrobase/conf/MacroBaseDefaults.java
@@ -50,8 +50,6 @@ public class MacroBaseDefaults {
     public static final Double TREE_KDE_ACCURACY = 1e-5;
 
     public static final String R_LOG_FILE = null;
-    // Analysis results
-    public static final String STORE_ANALYSIS_RESULTS = null;
 
     // loader defaults
     public static final DataIngesterType DATA_LOADER_TYPE = DataIngesterType.POSTGRES_LOADER;
@@ -75,4 +73,6 @@ public class MacroBaseDefaults {
     public static final Integer DPM_TRUNCATING_PARAMETER = 50;
     public static final Double DPM_CONCENTRATION_PARAMETER = 1.;
     public static final Integer MIXTURE_MAX_ITERATIONS_TO_CONVERGE = 100;
+    public static final MacroBaseConf.ClassifierType CLASSIFIER_TYPE = MacroBaseConf.ClassifierType.NORM_PERCENTILE;
+    public static final MacroBaseConf.DensityEstimaterType DENSITY_ESTIMATER_TYPE = MacroBaseConf.DensityEstimaterType.DPGMM;
 }

--- a/src/main/java/macrobase/datamodel/Datum.java
+++ b/src/main/java/macrobase/datamodel/Datum.java
@@ -10,8 +10,8 @@ public class Datum implements HasMetrics {
     private List<Integer> attributes;
     private RealVector metrics;
     private RealVector auxiliaries;
+    private double density;
 
-    
     private List<Integer> contextualDiscreteAttributes;
     private RealVector contextualDoubleAttributes;
     
@@ -83,6 +83,14 @@ public class Datum implements HasMetrics {
         } else {
             return new ArrayRealVector(0);
         }
+    }
+
+    public void setDensity(double density) {
+        this.density = density;
+    }
+
+    public double getDensity() {
+        return density;
     }
     
 }

--- a/src/main/java/macrobase/diagnostics/JsonUtils.java
+++ b/src/main/java/macrobase/diagnostics/JsonUtils.java
@@ -23,4 +23,14 @@ public class JsonUtils {
         PrintStream out = new PrintStream(new File(dir, filename), "UTF-8");
         out.println(gson.toJson(object));
     }
+
+    public static void tryToDumpAsJson(Object object, String filename) {
+        try {
+            dumpAsJson(object, filename);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/macrobase/util/DiagnosticsUtils.java
+++ b/src/main/java/macrobase/util/DiagnosticsUtils.java
@@ -9,18 +9,13 @@ import java.util.List;
 
 public class DiagnosticsUtils {
 
-    public static List<Datum> create2DGrid(double[][] boundaries, double delta) {
+    public static List<Datum> createGridFixedIncrement(double[][] boundaries, double delta) {
         int dimension = boundaries.length;
         int[] dimensionPoints = new int[dimension];
         int size = 1;
         for (int d = 0; d < dimension; d++) {
             dimensionPoints[d] = (int) ((boundaries[d][1] - boundaries[d][0]) / delta + 1);
             size *= dimensionPoints[d];
-        }
-        List<Datum> scoredData = new ArrayList<>((int) size);
-        double[] point = new double[dimension];
-        for (int d = 0; d < dimension; d++) {
-            point[d] = boundaries[d][0];
         }
 
         List<RealVector> gridPointVectors = new ArrayList<>(dimension);
@@ -33,15 +28,52 @@ public class DiagnosticsUtils {
             gridPointVectors.add(new ArrayRealVector(array));
         }
 
+        return convertToGrid(gridPointVectors);
+    }
+
+    private static List<Datum> convertToGrid(List<RealVector> anchors) {
+        // TODO: Currently only supports 1D and 2D grids.
+        int size = 1;
+        for (RealVector v : anchors) {
+            size *= v.getDimension();
+        }
+        int dimension = anchors.size();
         List<Datum> grid = new ArrayList<>(size);
-        double[] array = new double[2];
-        for (int i = 0; i < dimensionPoints[0]; i++) {
-            array[0] = gridPointVectors.get(0).getEntry(i);
-            for (int j = 0; j < dimensionPoints[1]; j++) {
-                array[1] = gridPointVectors.get(1).getEntry(j);
+        double[] array = new double[dimension];
+        if (dimension == 1) {
+            for (double x : anchors.get(0).toArray()) {
+                array[0] = x;
                 grid.add(new Datum(new ArrayList<Integer>(), new ArrayRealVector(array)));
+            }
+        } else if (dimension == 2) {
+            for (double x : anchors.get(0).toArray()) {
+                array[0] = x;
+                for (double y : anchors.get(1).toArray()) {
+                    array[1] = y;
+                    grid.add(new Datum(new ArrayList<Integer>(), new ArrayRealVector(array)));
+                }
             }
         }
         return grid;
+    }
+
+    public static List<Datum> createGridFixedSize(double[][] boundaries, int pointsPerDimension) {
+        int dimension = boundaries.length;
+        double delta[] = new double[dimension];
+        for (int d = 0; d < dimension; d++) {
+            delta[d] = (boundaries[d][1] - boundaries[d][0]) / (pointsPerDimension - 1.);
+        }
+
+        List<RealVector> gridPointVectors = new ArrayList<>(dimension);
+
+        for (int d = 0; d < dimension; d++) {
+            double[] array = new double[pointsPerDimension];
+            for (int i = 0; i < pointsPerDimension; i++) {
+                array[i] = boundaries[d][0] + i * delta[d];
+            }
+            gridPointVectors.add(new ArrayRealVector(array));
+        }
+
+        return convertToGrid(gridPointVectors);
     }
 }

--- a/src/test/java/macrobase/analysis/stats/VariationalDPMGTest.java
+++ b/src/test/java/macrobase/analysis/stats/VariationalDPMGTest.java
@@ -6,7 +6,7 @@ import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.datamodel.Datum;
 import macrobase.diagnostics.JsonUtils;
-import macrobase.diagnostics.ScoreDumper;
+import macrobase.diagnostics.DensityDumper;
 import macrobase.ingest.CSVIngester;
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.RealVector;
@@ -84,12 +84,12 @@ public class VariationalDPMGTest {
         JsonUtils.dumpAsJson(variationalDPGM.getClusterCenters(), "VariationalDPMGTest-bivariateWellSeparatedNormalTest-means.json");
         JsonUtils.dumpAsJson(variationalDPGM.getClusterWeights(), "VariationalDPMGTest-bivariateWellSeparatedNormalTest-weights.json");
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-700-grid.json");
-        ScoreDumper dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-700-grid.json");
+        DensityDumper dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalDPGM, boundaries, 0.05);
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-700-data.json");
-        dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-700-data.json");
+        dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalDPGM, data);
 
 
@@ -178,12 +178,12 @@ public class VariationalDPMGTest {
         JsonUtils.dumpAsJson(variationalDPGM.getClusterCenters(), "VariationalDPMGTest-bivariateOkSeparatedNormalTest-means.json");
         JsonUtils.dumpAsJson(variationalDPGM.getClusterWeights(), "VariationalDPMGTest-bivariateOkSeparatedNormalTest-weights.json");
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-7k-grid.json");
-        ScoreDumper dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-7k-grid.json");
+        DensityDumper dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalDPGM, boundaries, 0.05);
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-7k-data.json");
-        dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-7k-data.json");
+        dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalDPGM, data);
     }
 }

--- a/src/test/java/macrobase/analysis/stats/VariationalGMMTest.java
+++ b/src/test/java/macrobase/analysis/stats/VariationalGMMTest.java
@@ -7,7 +7,7 @@ import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.datamodel.Datum;
 import macrobase.diagnostics.JsonUtils;
-import macrobase.diagnostics.ScoreDumper;
+import macrobase.diagnostics.DensityDumper;
 import macrobase.ingest.CSVIngester;
 import macrobase.util.DiagnosticsUtils;
 import org.apache.commons.math3.linear.ArrayRealVector;
@@ -197,18 +197,18 @@ public class VariationalGMMTest {
                 {0, 6.01},
                 {-2, 4.01},
         };
-        List<Datum> scoredData = DiagnosticsUtils.create2DGrid(boundaries, 0.05);
+        List<Datum> scoredData = DiagnosticsUtils.createGridFixedIncrement(boundaries, 0.05);
 
         JsonUtils.dumpAsJson(variationalGMM.getCovariances(), "VariationalGMMTest-bivariateOkSeparatedNormalTest-covariances.json");
         JsonUtils.dumpAsJson(variationalGMM.getMeans(), "VariationalGMMTest-bivariateOkSeparatedNormalTest-means.json");
         JsonUtils.dumpAsJson(variationalGMM.getPriorAdjustedWeights(), "VariationalGMMTest-bivariateOkSeparatedNormalTest-weights.json");
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-7k-grid.json");
-        ScoreDumper dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-7k-grid.json");
+        DensityDumper dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalGMM, scoredData);
 
-        conf.set(MacroBaseConf.SCORE_DUMP_FILE_CONFIG_PARAM, "3gaussians-7k-data.json");
-        dumper = new ScoreDumper(conf);
+        conf.set(MacroBaseConf.SCORED_DATA_FILE, "3gaussians-7k-data.json");
+        dumper = new DensityDumper(conf);
         dumper.dumpScores(variationalGMM, data);
     }
 

--- a/src/test/java/macrobase/pipeline/BasicBatchedPipelineTest.java
+++ b/src/test/java/macrobase/pipeline/BasicBatchedPipelineTest.java
@@ -80,6 +80,8 @@ public class BasicBatchedPipelineTest {
                 .set(MacroBaseConf.LOW_METRICS, new ArrayList<>())
                 .set(MacroBaseConf.HIGH_METRICS, Lists.newArrayList("XX"))
                 .set(MacroBaseConf.AUXILIARY_ATTRIBUTES, "")
+                .set(MacroBaseConf.DUMP_DENSITY_GRID_TO, "junk.json")
+                .set(MacroBaseConf.SCORED_DATA_FILE, "points.json")
                 .set(MacroBaseConf.DATA_LOADER_TYPE, MacroBaseConf.DataIngesterType.CSV_LOADER)
                 .set(MacroBaseConf.CSV_COMPRESSION, CSVIngester.Compression.UNCOMPRESSED)
                 .set(MacroBaseConf.CSV_INPUT_FILE, "src/test/resources/data/20points.csv");

--- a/src/test/java/macrobase/pipeline/BasicBatchedPipelineTest.java
+++ b/src/test/java/macrobase/pipeline/BasicBatchedPipelineTest.java
@@ -65,6 +65,50 @@ public class BasicBatchedPipelineTest {
     }
 
     @Test
+    public void testGMMDensityClassifier() throws Exception {
+        MacroBaseConf conf = new MacroBaseConf()
+                .set(MacroBaseConf.TRANSFORM_TYPE, MacroBaseConf.TransformType.IDENTITY)
+                .set(MacroBaseConf.DENSITY_ESTIMATER_TYPE, MacroBaseConf.DensityEstimaterType.GMM)
+                .set(MacroBaseConf.NUM_MIXTURES, 1)
+                .set(MacroBaseConf.CLASSIFIER_TYPE, MacroBaseConf.ClassifierType.DENSITY_PERCENTILE)
+                .set(MacroBaseConf.TARGET_PERCENTILE, 0.99) // analysis
+                .set(MacroBaseConf.USE_PERCENTILE, true)
+                .set(MacroBaseConf.MIN_OI_RATIO, .01)
+                .set(MacroBaseConf.MIN_SUPPORT, .01)
+                .set(MacroBaseConf.RANDOM_SEED, 0)
+                .set(MacroBaseConf.ATTRIBUTES, Lists.newArrayList("XX")) // loader
+                .set(MacroBaseConf.LOW_METRICS, new ArrayList<>())
+                .set(MacroBaseConf.HIGH_METRICS, Lists.newArrayList("XX"))
+                .set(MacroBaseConf.AUXILIARY_ATTRIBUTES, "")
+                .set(MacroBaseConf.DATA_LOADER_TYPE, MacroBaseConf.DataIngesterType.CSV_LOADER)
+                .set(MacroBaseConf.CSV_COMPRESSION, CSVIngester.Compression.UNCOMPRESSED)
+                .set(MacroBaseConf.CSV_INPUT_FILE, "src/test/resources/data/20points.csv");
+
+        conf.loadSystemProperties();
+        conf.sanityCheckBatch();
+
+        AnalysisResult ar = (new BasicBatchedPipeline(conf)).next();
+
+        assertEquals(1, ar.getItemSets().size());
+
+        HashSet<String> toFindColumn = Sets.newHashSet("XX");
+        HashSet<String> toFindValue = Sets.newHashSet("-5.8");
+
+        for (ColumnValue cv : ar.getItemSets().get(0).getItems()) {
+            assertTrue(toFindColumn.contains(cv.getColumn()));
+            toFindColumn.remove(cv.getColumn());
+            assertTrue(toFindValue.contains(cv.getValue()));
+            toFindValue.remove(cv.getValue());
+        }
+
+        assertEquals(0, toFindColumn.size());
+        assertEquals(0, toFindValue.size());
+
+        assertEquals(ar.getNumInliers(), 19, 1e-9);
+        assertEquals(ar.getNumOutliers(), 1, 1e-9);
+    }
+
+    @Test
     public void testSensor10KPower() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
                 .set(MacroBaseConf.TARGET_PERCENTILE, 0.99) // analysis
@@ -178,9 +222,7 @@ public class BasicBatchedPipelineTest {
         assertEquals(0, toFindColumn.size());
         assertEquals(0, toFindValue.size());
     }
-    
-    
-    
+
     @Test
     public void testContextualMADAnalyzer() throws Exception {
     	 MacroBaseConf conf = new MacroBaseConf()
@@ -206,7 +248,5 @@ public class BasicBatchedPipelineTest {
         AnalysisResult ar = (new BasicBatchedPipeline(conf)).next();
 
         assertEquals(0, ar.getItemSets().size());
-
-     
     }
 }

--- a/src/test/java/macrobase/util/DiagnosticsUtilsTest.java
+++ b/src/test/java/macrobase/util/DiagnosticsUtilsTest.java
@@ -15,17 +15,17 @@ public class DiagnosticsUtilsTest {
     /**
      * test 2D grid construction for a simple case.
      */
-    public void testGrid() {
+    public void test2DGrid() {
         double[][] boundaries = {
-                {1, 2.001},
-                {1, 2.001},
+                {1, 2.000001},
+                {1, 2.000001},
         };
         List<Datum> grid;
 
-        grid = DiagnosticsUtils.create2DGrid(boundaries, 0.1);
+        grid = DiagnosticsUtils.createGridFixedIncrement(boundaries, 0.1);
         assertEquals(121, grid.size());
 
-        grid = DiagnosticsUtils.create2DGrid(boundaries, 0.5);
+        grid = DiagnosticsUtils.createGridFixedIncrement(boundaries, 0.5);
         assertEquals(9, grid.size());
 
         double[][] expectedGrid = {
@@ -52,5 +52,31 @@ public class DiagnosticsUtilsTest {
         for (int i = 0 ; i < 9 ; i++) {
             assertEquals(true, pointsSeen[i]);
         }
+
+        List<Datum> grid2 = DiagnosticsUtils.createGridFixedSize(boundaries, 3);
+        assertEquals(grid2.size(), 9);
+        for (int i = 0; i < 9; i++) {
+            for (int d=0; d < 2; d++) {
+                assertEquals(grid.get(i).getMetrics().getEntry(d), grid2.get(i).getMetrics().getEntry(d), 1e-5);
+            }
+        }
+    }
+
+    @Test
+    /**
+     * test 1D grid construction for a simple case.
+     */
+    public void test1DGrid() {
+        double[][] boundaries = {
+                {1, 2.000001},
+        };
+        List<Datum> grid;
+        grid = DiagnosticsUtils.createGridFixedIncrement(boundaries, 0.5);
+        assertEquals(3, grid.size());
+        grid = DiagnosticsUtils.createGridFixedSize(boundaries, 6);
+        assertEquals(6, grid.size());
+        assertEquals(1.8, grid.get(4).getMetrics().getEntry(0), 1e-5);
+        assertEquals(1.2, grid.get(1).getMetrics().getEntry(0), 1e-5);
+
     }
 }

--- a/src/test/java/macrobase/util/JsonUtilsTest.java
+++ b/src/test/java/macrobase/util/JsonUtilsTest.java
@@ -1,0 +1,25 @@
+package macrobase.util;
+
+import macrobase.diagnostics.JsonUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.UnsupportedEncodingException;
+
+public class JsonUtilsTest {
+    private static final Logger log = LoggerFactory.getLogger(JsonUtilsTest.class);
+
+    @Test(expected=FileNotFoundException.class)
+    public void unnecessaryTest() throws FileNotFoundException, UnsupportedEncodingException {
+        double[] array = {1, 2, 2.4};
+        JsonUtils.dumpAsJson(array, "nonExistingFolder/nonExistingDirectory");
+    }
+
+    @Test
+    public void unnecessaryTestWithoutException() {
+        double[] array = {1, 2, 2.4};
+        JsonUtils.tryToDumpAsJson(array, "nonExistingFolder/nonExistingDirectory");
+    }
+}


### PR DESCRIPTION
Add some constructs to Macrobase to be able to use Density Estimators (e.g. KDE, GMM, etc.) as bases for classification (instead of using percentile classifier after running those classes as transform)