### PR TITLE
Fluent Pipeline API

### DIFF
--- a/src/main/java/macrobase/analysis/classify/OutlierClassifier.java
+++ b/src/main/java/macrobase/analysis/classify/OutlierClassifier.java
@@ -1,9 +1,8 @@
 package macrobase.analysis.classify;
 
-import macrobase.analysis.pipeline.operator.MBConsumer;
-import macrobase.analysis.pipeline.operator.MBProducer;
+import macrobase.analysis.pipeline.operator.MBOperator;
 import macrobase.analysis.result.OutlierClassificationResult;
 
 import macrobase.datamodel.Datum;
 
-public interface OutlierClassifier extends MBConsumer<Datum>, MBProducer<OutlierClassificationResult> { }
+public interface OutlierClassifier extends MBOperator<Datum, OutlierClassificationResult> { }

--- a/src/main/java/macrobase/analysis/pipeline/BasePipeline.java
+++ b/src/main/java/macrobase/analysis/pipeline/BasePipeline.java
@@ -35,7 +35,7 @@ public abstract class BasePipeline implements Pipeline {
     protected MacroBaseConf conf;
 
     @Override
-    public void initialize(MacroBaseConf conf) throws Exception {
+    public Pipeline initialize(MacroBaseConf conf) throws Exception {
         this.conf = conf;
 
         queryName = conf.getString(MacroBaseConf.QUERY_NAME, MacroBaseDefaults.QUERY_NAME);
@@ -67,5 +67,7 @@ public abstract class BasePipeline implements Pipeline {
                                                    MacroBaseDefaults.CONTEXTUAL_DENSECONTEXTTAU);
         contextualNumIntervals = conf.getInt(MacroBaseConf.CONTEXTUAL_NUMINTERVALS,
                                              MacroBaseDefaults.CONTEXTUAL_NUMINTERVALS);
+
+        return this;
     }
 }

--- a/src/main/java/macrobase/analysis/pipeline/Pipeline.java
+++ b/src/main/java/macrobase/analysis/pipeline/Pipeline.java
@@ -3,7 +3,11 @@ package macrobase.analysis.pipeline;
 import macrobase.analysis.result.AnalysisResult;
 import macrobase.conf.MacroBaseConf;
 
+/*
+ Basic MacroBase query pipeline interface.
+ Instances can be run programmatically via config option.
+ */
 public interface Pipeline {
-    void initialize(MacroBaseConf conf) throws Exception;
+    Pipeline initialize(MacroBaseConf conf) throws Exception;
     AnalysisResult run() throws Exception;
 }

--- a/src/main/java/macrobase/analysis/pipeline/operator/MBOperator.java
+++ b/src/main/java/macrobase/analysis/pipeline/operator/MBOperator.java
@@ -1,0 +1,3 @@
+package macrobase.analysis.pipeline.operator;
+
+public interface MBOperator<S, T> extends MBConsumer<S>, MBProducer<T> { }

--- a/src/main/java/macrobase/analysis/pipeline/operator/MBOperatorChain.java
+++ b/src/main/java/macrobase/analysis/pipeline/operator/MBOperatorChain.java
@@ -1,0 +1,73 @@
+package macrobase.analysis.pipeline.operator;
+
+import java.util.List;
+
+public class MBOperatorChain<F, T> {
+    private MBOperatorChain<?, F> parent;
+
+    private MBOperator<F, T> operator;
+
+    private MBStream<T> output = new MBStream<>();
+
+    // create a new chain with this producer at the head...
+    public static <T> MBOperatorChain<?, T> begin(MBProducer<T> head) throws Exception{
+        return new MBOperatorChain(head.getStream());
+    }
+
+    // create a new chain with this list as input...
+    public static <T> MBOperatorChain begin(List<T> feed) throws Exception {
+        return new MBOperatorChain(feed);
+    }
+
+    private MBOperatorChain(List<T> feed) {
+        this.output.add(feed);
+    }
+
+    private MBOperatorChain(MBStream<T> head) {
+        this.output = head;
+    }
+
+    private MBOperatorChain(MBOperatorChain<?, F> parent,
+                            MBOperator<F, T> operator) throws Exception {
+        this.parent = parent;
+        this.operator = operator;
+        this.output = operator.getStream();
+    }
+
+    // executeMiniBatch this operator after the current in the chain...
+    public MBOperatorChain then(MBOperator<F, T> cur) throws Exception {
+        return new MBOperatorChain(this, cur);
+    }
+
+    public MBStream<T> execute() throws Exception {
+        return execute(-1);
+    }
+
+    // execute the chain
+    private MBStream<T> execute(Integer batchSize) throws Exception {
+        if(parent != null) {
+            operator.consume(parent.execute(batchSize).drain(batchSize));
+        }
+
+        return output;
+    }
+
+    // execute in mini-batch mode, with batchSize tuples per iteration
+    // caller must repeatedly invoke this function...
+    public MBStream<T> executeMiniBatch(int batchSize) throws Exception {
+        return execute(batchSize);
+    }
+
+    public MBStream<T> executeMiniBatchUntilFixpoint(int batchSize) throws Exception {
+        int prevRemaining = -1;
+
+        MBStream<T> ret = execute(batchSize);
+
+        while(ret.remaining() != prevRemaining) {
+            prevRemaining = ret.remaining();
+            ret = execute(batchSize);
+        }
+
+        return ret;
+    }
+}

--- a/src/main/java/macrobase/analysis/pipeline/operator/MBStream.java
+++ b/src/main/java/macrobase/analysis/pipeline/operator/MBStream.java
@@ -20,4 +20,22 @@ public class MBStream<T> {
         output = new ArrayList<>();
         return ret;
     }
+
+    public List<T> drain(int maxElements) {
+        List<T> ret;
+
+        if(maxElements < 0 || output.size() <= maxElements) {
+            ret = output;
+            output = new ArrayList<>();
+        } else {
+            ret = output.subList(0, maxElements);
+            output = output.subList(maxElements, output.size());
+        }
+
+        return ret;
+    }
+
+    public Integer remaining() {
+        return output.size();
+    }
 }

--- a/src/main/java/macrobase/analysis/summary/Summarizer.java
+++ b/src/main/java/macrobase/analysis/summary/Summarizer.java
@@ -1,15 +1,11 @@
 package macrobase.analysis.summary;
 
-import macrobase.analysis.pipeline.operator.MBConsumer;
-import macrobase.analysis.pipeline.operator.MBProducer;
+import macrobase.analysis.pipeline.operator.MBOperator;
 import macrobase.analysis.result.OutlierClassificationResult;
-import macrobase.analysis.classify.OutlierClassifier;
-import macrobase.conf.MacroBaseConf;
-import macrobase.ingest.DatumEncoder;
 
 /**
  * Consumes OutlierClassification Result tuple-at-a-time, but returns summaries
  # when there has been an update.
  */
 
-public interface Summarizer extends MBConsumer<OutlierClassificationResult>, MBProducer<Summary> { }
+public interface Summarizer extends MBOperator<OutlierClassificationResult, Summary> { }

--- a/src/main/java/macrobase/analysis/transform/FeatureTransform.java
+++ b/src/main/java/macrobase/analysis/transform/FeatureTransform.java
@@ -1,7 +1,6 @@
 package macrobase.analysis.transform;
 
-import macrobase.analysis.pipeline.operator.MBConsumer;
-import macrobase.analysis.pipeline.operator.MBProducer;
+import macrobase.analysis.pipeline.operator.MBOperator;
 import macrobase.datamodel.Datum;
 
-public interface FeatureTransform extends MBConsumer<Datum>, MBProducer<Datum> { }
+public interface FeatureTransform extends MBOperator<Datum, Datum> {}

--- a/src/main/java/macrobase/runtime/command/MacroBasePipelineCommand.java
+++ b/src/main/java/macrobase/runtime/command/MacroBasePipelineCommand.java
@@ -30,10 +30,9 @@ public class MacroBasePipelineCommand extends ConfiguredCommand<MacroBaseConf> {
             log.error("{} is not an instance of Pipeline! Exiting...");
             return;
         }
-        Pipeline analyzer = (Pipeline) ao;
-        analyzer.initialize(configuration);
 
-        AnalysisResult result = analyzer.run();
+        AnalysisResult result = ((Pipeline) ao).initialize(configuration).run();
+
         if (result.getItemSets().size() > 1000) {
             log.warn("Very large result set! {}; truncating to 1000", result.getItemSets().size());
             result.setItemSets(result.getItemSets().subList(0, 1000));

--- a/src/main/java/macrobase/runtime/resources/AnalyzeResource.java
+++ b/src/main/java/macrobase/runtime/resources/AnalyzeResource.java
@@ -38,9 +38,7 @@ public class AnalyzeResource extends BaseResource {
         conf.set(MacroBaseConf.LOW_METRICS, request.lowMetrics);
         conf.set(MacroBaseConf.USE_PERCENTILE, true);
 
-        BasicBatchedPipeline analyzer = new BasicBatchedPipeline();
-        analyzer.initialize(conf);
-        AnalysisResult result = analyzer.run();
+        AnalysisResult result = new BasicBatchedPipeline().initialize(conf).run();
 
         if (result.getItemSets().size() > 1000) {
             log.warn("Very large result set! {}; truncating to 1000", result.getItemSets().size());


### PR DESCRIPTION
This PR provides a nicer way to write chains of operators.

For example:

        MBStream<Summary> s = OperatorChain.begin(data)
                                           .then(new BatchScoreFeatureTransform(conf, conf.getTransformType()))
                                           .then(new BatchingPercentileClassifier(conf))
                                           .then(new BatchSummarizer(conf))
                                           .execute();

There is also a microBatch API, which polls a configurable number of tuples from each operator in the chain (same constructor pattern with `then`, but different `execute` methods that accept the maximum number of tuples per batch passed between each operator).

You can see an example of microbatch [in the streaming pipeline](https://github.com/stanford-futuredata/macrobase/blob/e377fd9ed8efba3bf3e3782a8a867cf5d1e700de/src/main/java/macrobase/analysis/pipeline/BasicOneShotEWStreamingPipeline.java#L36): we execute the feature transform and classification incrementally, 1000 tuples at a time, until we run out of tuples to process (i.e., we hit fixpoint). Then we pass the entire stream to the summary stage.

The downside of this API is that it's pushing the limits of Java's type inference and sometimes requires love in terms of casting things. We also had to create a `OneToOneOperator` class to get around the fact that parameters can only implement a single interface.

The plus side of this API is that it makes the code marginally more readable (IMO) and is also type safe.

Happy to iterate, but figured it might be helpful (and an interesting experiment in how we can use the `MBStream` interface to play with things like micro-batching).