### PR TITLE
Bug fix: frontend should expect list of results.

### DIFF
--- a/src/main/resources/frontend/consoleController.js
+++ b/src/main/resources/frontend/consoleController.js
@@ -304,14 +304,16 @@ myApp.controller('analyzeController', ['$scope', '$http', '$window', 'configServ
 	        configService.analysisReceived()
 	        $scope.analyzeStr = "Analyze"
 
-            $scope.analysisResult = response.data;
+	    var result = response.data[0];
 
-            $scope.numOutliers = response.data.numOutliers
-            $scope.numInliers = response.data.numInliers
-            $scope.loadTime = response.data.loadTime
-            $scope.executionTime = response.data.executionTime
-            $scope.summarizationTime = response.data.summarizationTime
-            $scope.itemsets = response.data.itemSets
+            $scope.analysisResult = result;
+
+            $scope.numOutliers = result.numOutliers
+            $scope.numInliers = result.numInliers
+            $scope.loadTime = result.loadTime
+            $scope.executionTime = result.executionTime
+            $scope.summarizationTime = result.summarizationTime
+            $scope.itemsets = result.itemSets
 
             $scope.sortAnalysis("support");
 	    });


### PR DESCRIPTION
Following #106, pipelines return a list of AnalysisResult. The frontend expects a single AnalysisResult. There are at least two fixes:

 1. Have the frontend render the first AnalysisResult in the returned JSON.
 2. Have the server return the first AnalysisResult from the pipeline.

Option 1 seems better in the event that we ever want to do something with multiple AnalysisResult instances.

@vayu-stanford: This addresses the frontend bug.

It'd be nice to have end-to-end unit tests for the frontend, but, for now, I think it's probably overkill. This is the first instance I'm aware of that actually broke the frontend.