### PR TITLE
Tweakable SVI + Accuracy Tasks

### DIFF
--- a/bench/experiments/3gaussians-ok.yaml
+++ b/bench/experiments/3gaussians-ok.yaml
@@ -1,13 +1,21 @@
 macrobase:
   macrobase.pipeline.class: macrobase.analysis.pipeline.GridDumpingPipeline
-  macrobase.analysis.transformType: VARIATIONAL_GMM
+  macrobase.analysis.transformType: SVI_DPGMM
+  macrobase.analysis.minSupport: 100
   macrobase.analysis.stat.mixtures.numMixtures: 6
   macrobase.loader.attributes: [XX, YY]
   macrobase.loader.csv.file: src/test/resources/data/3gaussians-7000points.csv.gz
   macrobase.loader.csv.compression: GZIP
+  macrobase.analysis.stat.trainTestSplit: 0.9
   macrobase.loader.loaderType: CSV_LOADER
   macrobase.loader.targetHighMetrics: [XX, YY]
   macrobase.loader.targetLowMetrics: []
   macrobase.query.name: ok_gaussians_finite_gmm
 post_run:
+  - plot_score_contours: "--plot density --savefig exp.png \
+    --centers target/scores/centers-ok_gaussians_finite_gmm-mixtures.json \
+    --covariances target/scores/covariances-ok_gaussians_finite_gmm-mixtures.json \
+    --weights target/scores/weights-ok_gaussians_finite_gmm-mixtures.json \
+    --csv src/test/resources/data/3gaussians-7000points.csv.gz \
+    --hist2d XX YY"
   - plot_score_contours: "--plot density --savefig"

--- a/bench/experiments/phillips-density.yaml
+++ b/bench/experiments/phillips-density.yaml
@@ -1,13 +1,20 @@
 macrobase:
-  macrobase.query.name: phillips-GA-Nrtu
-  macrobase.analysis.minOIRatio: 3
-  macrobase.analysis.targetPercentile: 0.95
-  macrobase.pipeline.class: macrobase.analysis.pipeline.GridDumpingPipeline
-  macrobase.analysis.transformType: VARIATIONAL_GMM
-  macrobase.analysis.stat.mixtures.numMixtures: 5
-  macrobase.analysis.stat.mixtures.initalClusters: target/scores/centers-phillips-GA-Nrtu-mixtures.json
-  macrobase.loader.csv.file: target/phillips_data/power_usage_city_state_rtus-3000ppid.csv
+  macrobase.query.name: phillips-Nrtu
+  macrobase.pipeline.class: macrobase.analysis.pipeline.MixtureModelPipeline
+  macrobase.analysis.transformType: SVI_DPGMM
+  macrobase.analysis.stat.mixtures.numMixtures: 10
+  macrobase.analysis.stat.mixtures.initalClusters: /Users/arsen/Workspace/centers.json
   macrobase.analysis.stat.iterative.improvementCutoffRatio: 0.0001
+  macrobase.analysis.classify.targetGroup: "17, 9"
+  macrobase.diagnostic.dumpMixtureComponents: target/score/phillips-Nrtu.json
+  macrobase.loader.csv.file: target/phillips_data/power_usage_city_state_rtus.csv
+  macrobase.analysis.stat.svi.delay: 1
+  macrobase.analysis.stat.svi.forgettingRate: 0.8
+  macrobase.analysis.stat.mixtures.numMixtures: 3
+  macrobase.analysis.stat.svi.minibatchSize: 10000
+  macrobase.analysis.stat.dpm.truncatingParameter: 15
+  macrobase.analysis.stat.dpm.concentrationParameter: 0.2
+  macrobase.diagnostic.gridPointsPerDimension: 1000
   macrobase.loader.csv.compression: UNCOMPRESSED
   macrobase.loader.loaderType: CSV_LOADER
   macrobase.loader.attributes: [datasource_id, controller_id, city, num_rtus]
@@ -15,5 +22,5 @@ macrobase:
   macrobase.loader.targetLowMetrics: []
 post_run:
   - plot_score_contours: "--plot density --savefig --y-limits 0 24 --x-limits 0 45"
-  - plot_score_contours: "--plot density --savefig contours.png --y-limits 0 24 --x-limits 0 45 --centers target/scores/centers-phillips-GA-Nrtu-mixtures.json --covariances target/scores/covariances-phillips-GA-Nrtu-mixtures.json --weights target/scores/weights-phillips-GA-Nrtu-mixtures.json --logscore"
-  - plot_score_contours: "--plot noop --savefig cluster.png --y-limits 0 24 --x-limits 0 45 --centers target/scores/centers-phillips-GA-Nrtu-mixtures.json --covariances target/scores/covariances-phillips-GA-Nrtu-mixtures.json --weights target/scores/weights-phillips-GA-Nrtu-mixtures.json --csv target/phillips_data/power_usage_city_state_rtus-3000ppid.csv  --hist2d power_usage time --logscore"
+  - plot_score_contours: "--plot density --savefig contours.png --y-limits 0 24 --x-limits 0 45 --centers target/scores/centers-phillips-Nrtu-mixtures.json --covariances target/scores/covariances-phillips-Nrtu-mixtures.json --weights target/scores/weights-phillips-Nrtu-mixtures.json"
+  - plot_score_contours: "--plot noop --savefig cluster.png --y-limits 0 24 --x-limits 0 45 --centers target/scores/centers-phillips-Nrtu-mixtures.json --covariances target/scores/covariances-phillips-Nrtu-mixtures.json --weights target/scores/weights-phillips-Nrtu-mixtures.json --csv target/phillips_data/power_usage_city_state_rtus.csv  --hist2d power_usage time"

--- a/docs/parameters_desc.md
+++ b/docs/parameters_desc.md
@@ -219,6 +219,32 @@ used in the KDE outlier detection algorithm.
   Controls how many possible mixtures to have when doing Variational Inference approximation.
   </td>
 </tr>
+  <td><code>macrobase.analysis.stat.svi.forgettingRate</code></td>
+  <td><code>0.9</code></td>
+  <td>
+  This is a <b>Stochastic Variational Inference-only</b> parameter.
+  Controls the speed of stochastic gradient descent. Higher values
+  will keep the speed high as iterations grow.
+  </td>
+</tr>
+<tr>
+  <td><code>macrobase.analysis.stat.svi.delay</code></td>
+  <td><code>1.0</code></td>
+  <td>
+  This is a <b>Stochastic Variational Inference-only</b> parameter.
+  Controls the speed of stochastic gradient descent, unless you
+  know that you need to change this paramater don't. Control the
+  speed using `macrobase.analysis.stat.svi.forgettingRate`.
+  </td>
+</tr>
+<tr>
+  <td><code>macrobase.analysis.stat.svi.minibatchSize</code></td>
+  <td><code>10000</code></td>
+  <td>
+  This is a <b>Stochastic Variational Inference-only</b> parameter.
+  Controls the size of minibatch to use to split the data into smaller chunks (minibatches).
+  </td>
+</tr>
 </table>
 
 ## Streaming-specific parameters

--- a/script/py_analysis/cluster_animation.py
+++ b/script/py_analysis/cluster_animation.py
@@ -1,0 +1,122 @@
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import patches
+import re
+import matplotlib.animation as animation
+from algebra import get_ellipse_from_covariance
+
+
+def parse_args(*argument_list):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('log_file')
+  args = parser.parse_args(*argument_list)
+  return args
+
+
+def update_atoms(lines, i):
+  clusters = {}
+  for i in range(i, len(lines)):
+    if not re.search('macrobase.analysis.stats.mixture.NormalWishartClusters: \d+', lines[i]):
+      return clusters
+    print lines[i]
+    ci = int(re.search('macrobase.analysis.stats.mixture.NormalWishartClusters: (\d)', lines[i]).group(1))
+    weight = re.search('weight: (\d+.\d+)', lines[i]).group(1)
+    mean = re.search('mean: {([-]?\d+.\d+; [-]?\d+.\d+)}', lines[i]).group(1)
+    mean = [float(x) for x in mean.split(';')]
+    covObj = re.search('cov: Array2DRowRealMatrix{{([-]?\d+.\d+,[-]?\d+.\d+)},{([-]?\d+.\d+,[-]?\d+.\d+)}}', lines[i])
+    beta = float(re.search('beta: ([-]?\d+.\d+)', lines[i]).group(1))
+    dof = float(re.search('dof: (\d+.\d+)', lines[i]).group(1))
+    scale = (dof + 1 - 2) * beta / (1 + beta)
+    print 'beta, dof, scale', beta, dof, scale
+    cov = [[scale * float(x) for x in covObj.group(1).split(',')],
+           [scale * float(x) for x in covObj.group(2).split(',')]]
+    clusters[ci] = (mean, cov)
+  return clusters
+
+
+def update_weights(lines, i):
+  coeffs_text = lines[i].split('coeffs:')[-1].strip()
+  coeffs_text = coeffs_text.strip('[]')
+  return [float(x) for x in coeffs_text.split(',')]
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  with open(args.log_file) as infile:
+    lines = list(infile)
+  updated_weights, updated_atoms = False, False
+  data = []
+  for i in range(len(lines)):
+    if re.search('MultiComponents.(moveNatural|update)', lines[i]):
+      weights = update_weights(lines, i+1)
+      updated_weights = True
+    if re.search('NormalWishartClusters.(moveNatural|update)', lines[i]):
+      atoms = update_atoms(lines, i+1)
+      updated_atoms = True
+    if updated_weights and updated_atoms:
+      data.append((weights, atoms))
+      updated_weights, updated_atoms = False, False
+
+  fig = plt.figure()
+  ax = fig.add_subplot(111, aspect='equal')
+
+  def original_clusters():
+    clusters = [[(1.5,2),((0.5,0.4),(0.4,0.5)),50000],
+                [(2,0),((0.3,0),(0,0.6)),30000],
+                [(4.5,1),((0.9,0.2),(0.2,0.3)),20000]]
+    artists = []
+    for center, cov, weight in clusters:
+      w, h, angle = get_ellipse_from_covariance(cov)
+      e = patches.Ellipse(center, w, h, angle=angle, color='r')
+      e.set_alpha(1. * weight / 60000)
+      artists.append(e)
+    return artists
+
+  list_of_lists = []
+
+  for weights, atoms in data:
+    _list = []
+    for i, (center, sigma) in atoms.iteritems():
+      w, h, angle = get_ellipse_from_covariance(sigma)
+      print w, h, (center, sigma), weights[i]
+      e = patches.Ellipse(center, w, h, angle=angle, label='%d' % i)
+      e.set_alpha(weights[i] / 70000)
+      #ax.add_artist(e)
+      _list.append(e)
+    list_of_lists.append(_list)
+
+  def init():
+    print 'init()'
+    ax.set_xlim([0, 6])
+    ax.set_ylim([-1.5, 4.5])
+    #ax.add_artist(list_of_lists[i][0])
+
+  def animate(i):
+    print 'animate', i
+    ax.cla()
+    arts = original_clusters()
+    print arts
+    for a in arts:
+      ax.add_artist(a)
+    for art in list_of_lists[i]:
+      ax.add_artist(art)
+    return list_of_lists[i]
+
+  print 'ani'
+  print 'len(..', len(list_of_lists)
+
+  ani = animation.FuncAnimation(fig, animate, np.arange(1, len(list_of_lists)),
+                                interval=1000, blit=False, init_func=init)
+
+  # init()
+  # print list_of_lists[0][0]
+  # ax.add_artist(list_of_lists[0][0])
+ #  ani = animation.ArtistAnimation(fig, list_of_lists, interval=50, blit=False,
+ #                                  repeat_delay=1000)
+
+  # init()
+  # for a in add_actual_clusters():
+  #   ax.add_artist(a)
+
+  plt.show()

--- a/script/py_analysis/common.py
+++ b/script/py_analysis/common.py
@@ -77,6 +77,7 @@ def set_ax_limits(ax, args):
 
 
 def set_plot_limits(plt, args):
+  print 'setting plot limits'
   if args.xlabel:
     plt.xlabel(args.xlabel)
   if args.ylabel:

--- a/script/py_analysis/phillips_subsample.py
+++ b/script/py_analysis/phillips_subsample.py
@@ -1,0 +1,30 @@
+import argparse
+from random import sample
+import pandas as pd
+
+
+def parse_args(*argument_list):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('csv', type=argparse.FileType('r'))
+  parser.add_argument('outcsv', type=argparse.FileType('w'))
+  parser.add_argument('--points-per-controller', type=int, default=2000)
+  args = parser.parse_args(*argument_list)
+  return args
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  df = pd.read_csv(args.csv)
+  distinct_controllers = set(df['controller_id'])
+  print 'total controller_ids included =', len(distinct_controllers)
+
+  sampled_df = None
+  frames = []
+  for cid in distinct_controllers:
+    cntl_df = df[df['controller_id'] == cid]
+    x = cntl_df.loc[sample(cntl_df.index, min(cntl_df.shape[0], args.points_per_controller))]
+    frames.append(x)
+
+  sampled_df = pd.concat(frames)
+  print 'dumpnig total %d rows' % sampled_df.shape[0]
+  sampled_df.to_csv(args.outcsv, index=False)

--- a/script/py_analysis/plot_distribution.py
+++ b/script/py_analysis/plot_distribution.py
@@ -3,6 +3,8 @@ Plots a scatter plot of 2 metrics provided.
 Data could be given from postgres or a csv file.
 """
 from matplotlib.colors import LogNorm
+import sys
+import numpy as np
 import argparse
 import matplotlib
 import matplotlib.pyplot as plt
@@ -17,7 +19,7 @@ def parse_args(*argument_list):
   parser = argparse.ArgumentParser()
 
   source_group = parser.add_mutually_exclusive_group(required=True)
-  source_group.add_argument('--csv', type=argparse.FileType('r'))
+  source_group.add_argument('--csv')
   source_group.add_argument('--table', default='car_data_demo')
 
 
@@ -48,9 +50,9 @@ def parse_args(*argument_list):
 
 
 def _plot_hist2d(data, args):
-  print data.shape
-  args.data[args.hist2d[0]]
-  args.data[args.hist2d[1]]
+  data = data[data[args.hist2d[0]].notnull()][data[args.hist2d[1]].notnull()]
+  if data.shape[0] < 1000:
+    sys.exit(1)
   plt.hist2d(data[args.hist2d[0]],
              data[args.hist2d[1]],
              bins=args.histogram_bins,
@@ -59,6 +61,8 @@ def _plot_hist2d(data, args):
   set_plot_limits(plt, args)
   plt.xlabel(args.hist2d[0])
   plt.ylabel(args.hist2d[1])
+  set_plot_limits(plt, args)
+  plt.title("N = {}".format(data.shape[0]))
 
 
 def plot_distribution(args):
@@ -74,6 +78,7 @@ def plot_distribution(args):
     data = pd.DataFrame(cursor.fetchall(), columns=colnames)
   else:
     data = pd.read_csv(args.csv)
+    print ' '.join(list(data.columns.values))
     if args.filter_num_rtus:
       print 'before filtering size =', data.shape[0]
       data = data[data['num_rtus'] == args.filter_num_rtus]

--- a/script/py_analysis/plot_loglike.py
+++ b/script/py_analysis/plot_loglike.py
@@ -1,0 +1,73 @@
+"""
+Given a directory with log likelihood logs, for each file plots log
+likelihood movement based on iteration or time.
+"""
+import argparse
+import os
+import re
+import datetime
+import matplotlib.pyplot as plt
+
+
+t_regex = re.compile('(2016)-(\d+)-(\d+) (\d+)[:](\d+)[:](\d+),(\d+)')
+start_regex = re.compile('macrobase.util.TrainTestSpliter: nextDouble()')
+regex = re.compile('iteration (\d+) is ([-]\d+[.]\d+)')
+
+
+def parse_args(*argument_list):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('directory',
+                      help='Directory with macrobase log files that contain '
+                           'log likelihood logs.')
+  parser.add_argument('--x-axis', choices=['time', 'iteration'],
+                      default='iteration',
+                      help='Variable to plot on x axis')
+  return parser.parse_args(*argument_list)
+
+
+def get_time(line):
+  return datetime.datetime(*[int(x) for x in t_regex.search(line).groups()])
+
+
+def get_time_points(logfile):
+  lls = []
+  start_time = None
+  with open(logfile, 'r') as infile:
+    for line in infile:
+      if not start_time and start_regex.search(line):
+        start_time = get_time(line)
+      pattern = regex.search(line)
+      if pattern:
+        t = (get_time(line) - start_time).total_seconds()
+        ll = float(pattern.group(2))
+        lls.append((t, ll))
+  return zip(*lls)
+
+
+def get_iter_points(logfile):
+  lls = []
+  with open(logfile, 'r') as infile:
+    for line in infile:
+      pattern = regex.search(line)
+      if pattern:
+        i = int(pattern.group(1))
+        ll = float(pattern.group(2))
+        lls.append((i, ll))
+  return zip(*lls)
+
+
+def sterilize(name):
+  return name
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  for model in os.listdir(args.directory):
+    get_points = get_time_points if args.x_axis == 'time' else get_iter_points
+    x, y = get_points(os.path.join(args.directory, model))
+    print model, x, y
+    plt.plot(x, y, label=sterilize(model))
+  plt.xlabel(args.x_axis)
+  plt.ylabel('log liklihood')
+  plt.legend(loc='bottom right')
+  plt.show()

--- a/script/py_analysis/plot_score_contours.py
+++ b/script/py_analysis/plot_score_contours.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 import pandas as pd
+from common import set_ax_limits
 from algebra import get_ellipse_from_covariance
 from common import add_plot_limit_args
 from common import set_plot_limits
@@ -27,12 +28,13 @@ def parse_args(*argument_list):
   parser.add_argument('--scored-grid',
                       default='target/scores/3gaussians-7k-grid.json')
   parser.add_argument('--score-cap', type=float)
+  parser.add_argument('--score-lower-limit', type=float)
   parser.add_argument('--plot', default='density',
                       choices=['density', 'components', 'difference', 'noop'])
   # histogram
   parser.add_argument('--hist2d', nargs=2)
   parser.add_argument('--histogram-bins', type=int, default=100)
-  parser.add_argument('--csv', type=argparse.FileType('r'))
+  parser.add_argument('--csv')
   # centers
   parser.add_argument('--centers', type=argparse.FileType('r'))
   parser.add_argument('--weights', type=argparse.FileType('r'))
@@ -74,13 +76,14 @@ def load_cluster_parameters(filename):
 
 
 def plot_score_contours(args):
+  weights = []
+  centers = []
+  sigmas = []
   if args.centers and args.covariances and args.weights:
     # normalize weights to sum to 1.
     weights = json.load(args.weights)
     weights = [w / sum(weights) for w in weights]
-    print weights
     weights = [0.4 * w / max(weights) for w in weights]
-    print weights
     centers = load_cluster_parameters(args.centers)
     sigmas = load_cluster_parameters(args.covariances)
     fig = plt.figure(0)
@@ -90,6 +93,7 @@ def plot_score_contours(args):
       e = patches.Ellipse(centers[i], w, h, angle=angle)
       e.set_alpha(weights[i])
       ax.add_artist(e)
+      print i, weights[i], centers[i], sigmas[i]
     set_ax_limits(ax, args)
     x, y = zip(*centers)
     plt.scatter(x, y, s=weights)
@@ -98,37 +102,25 @@ def plot_score_contours(args):
 
   if args.score_cap:
     Z = [min(z, args.score_cap) for z in Z]
-
-  minX, maxX = min(X), max(X)
-  minY, maxY = min(Y), max(Y)
+  if args.score_lower_limit:
+    Z = [max(z, args.score_lower_limit) for z in Z]
 
   size = int(math.sqrt(len(Z)))
   X = np.reshape(X, (size, size))
   Y = np.reshape(Y, (size, size))
   Z = np.reshape(Z, (size, size))
 
-  try:
-    means = load_cluster_parameters('target/scores/{0.test_class}-{0.test_method}-means.json'.format(args))  # noqa
-    sigmas = load_cluster_parameters('target/scores/{0.test_class}-{0.test_method}-covariances.json'.format(args))  # noqa
-    with open('target/scores/{0.test_class}-{0.test_method}-weights.json'.format(args)) as infile:  # noqa
-      weights = json.load(infile)
-
-    # normalize weights to sum to 1.
-    weights = [w / sum(weights) for w in weights]
-  except:
-    pass
-
   def format_args(i):
     kwargs = {}
-    kwargs['mux'] = means[i][0]
-    kwargs['muy'] = means[i][1]
+    kwargs['mux'] = centers[i][0]
+    kwargs['muy'] = centers[i][1]
     kwargs['sigmax'] = math.sqrt(sigmas[i][0][0])
     kwargs['sigmay'] = math.sqrt(sigmas[i][1][1])
     kwargs['sigmaxy'] = sigmas[i][0][1]
     return kwargs
 
   Zgaussians = weights[0] * mlab.bivariate_normal(X, Y, **format_args(0))
-  for i in range(1, len(means)):
+  for i in range(1, len(centers)):
     Zgaussians += weights[i] * mlab.bivariate_normal(X, Y, **format_args(i))
 
   if args.plot == 'components':

--- a/src/main/java/macrobase/analysis/stats/distribution/Mixture.java
+++ b/src/main/java/macrobase/analysis/stats/distribution/Mixture.java
@@ -1,0 +1,27 @@
+package macrobase.analysis.stats.distribution;
+
+import org.apache.commons.math3.linear.RealVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class Mixture implements MultivariateDistribution {
+    private static final Logger log = LoggerFactory.getLogger(Mixture.class);
+    private List<MultivariateDistribution> components;
+    private double[] weights;
+
+    public Mixture(List<MultivariateDistribution> components, double[] weights) {
+        this.components = components;
+        this.weights = weights;
+    }
+
+    @Override
+    public double density(RealVector vector) {
+        double d = 0;
+        for (int i=0; i< components.size(); i++) {
+            d += components.get(i).density(vector) * weights[i];
+        }
+        return d;
+    }
+}

--- a/src/main/java/macrobase/analysis/stats/distribution/MultivariateDistribution.java
+++ b/src/main/java/macrobase/analysis/stats/distribution/MultivariateDistribution.java
@@ -1,0 +1,7 @@
+package macrobase.analysis.stats.distribution;
+
+import org.apache.commons.math3.linear.RealVector;
+
+public interface MultivariateDistribution {
+    double density(RealVector vector);
+}

--- a/src/main/java/macrobase/analysis/stats/distribution/MultivariateNormal.java
+++ b/src/main/java/macrobase/analysis/stats/distribution/MultivariateNormal.java
@@ -7,7 +7,7 @@ import org.apache.commons.math3.linear.RealVector;
 /**
  * Wrapper around MultivariateNormalDistribution that operates with RealVector and RealMatrix
  */
-public class MultivariateNormal {
+public class MultivariateNormal implements MultivariateDistribution {
     private MultivariateNormalDistribution distribution;
 
     public MultivariateNormal(RealVector mean, RealMatrix sigma) {

--- a/src/main/java/macrobase/analysis/stats/distribution/MultivariateTDistribution.java
+++ b/src/main/java/macrobase/analysis/stats/distribution/MultivariateTDistribution.java
@@ -8,7 +8,7 @@ import org.apache.commons.math3.special.Gamma;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MultivariateTDistribution {
+public class MultivariateTDistribution implements MultivariateDistribution{
     private static final Logger log = LoggerFactory.getLogger(MultivariateTDistribution.class);
     private RealVector mean;
     private RealMatrix precisionMatrix;

--- a/src/main/java/macrobase/analysis/stats/distribution/Wishart.java
+++ b/src/main/java/macrobase/analysis/stats/distribution/Wishart.java
@@ -3,8 +3,11 @@ package macrobase.analysis.stats.distribution;
 import org.apache.commons.math3.linear.EigenDecomposition;
 import org.apache.commons.math3.linear.RealMatrix;
 import org.apache.commons.math3.special.Gamma;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Wishart {
+    private static final Logger log = LoggerFactory.getLogger(Wishart.class);
     private final double logDetOmega;
     private RealMatrix omega;
     private double nu;
@@ -14,7 +17,12 @@ public class Wishart {
         this.omega = omega;
         this.nu = nu;
         this.D = omega.getColumnDimension();
-        this.logDetOmega = Math.log((new EigenDecomposition(omega)).getDeterminant());
+        if (omega.getRowDimension() == 2) {
+            this.logDetOmega = Math.log(omega.getEntry(0, 0) * omega.getEntry(1, 1) - omega.getEntry(1, 0) * omega.getEntry(0, 1));
+        } else {
+            log.debug("omega: {}", omega);
+            this.logDetOmega = Math.log((new EigenDecomposition(omega)).getDeterminant());
+        }
     }
 
     /**

--- a/src/main/java/macrobase/analysis/stats/mixture/DPGMM.java
+++ b/src/main/java/macrobase/analysis/stats/mixture/DPGMM.java
@@ -24,14 +24,13 @@ public class DPGMM extends VarGMM {
         mixingComponents = new DPComponents(concentrationParameter, T);
     }
 
-    @Override
-    public void train(List<Datum> data) {
+    public void trainTest(List<Datum> trainData, List<Datum> testData) {
         // 0. Initialize all approximating factors
-        clusters = new NormalWishartClusters(T, data.get(0).getMetrics().getDimension());
-        clusters.initializeBaseForDP(data);
-        clusters.initializeAtomsForDP(data, conf.getRandom());
+        clusters = new NormalWishartClusters(T, trainData.get(0).getMetrics().getDimension());
+        clusters.initializeBaseForDP(trainData);
+        clusters.initializeAtomsForDP(trainData, initialClusterCentersFile, conf.getRandom());
 
-        VariationalInference.trainMeanField(this, data, mixingComponents, clusters);
+        VariationalInference.trainTestMeanField(this, trainData, testData, mixingComponents, clusters);
     }
 
     @Override

--- a/src/main/java/macrobase/analysis/stats/mixture/ExpectMaxGMM.java
+++ b/src/main/java/macrobase/analysis/stats/mixture/ExpectMaxGMM.java
@@ -4,6 +4,7 @@ import macrobase.analysis.stats.distribution.MultivariateNormal;
 import macrobase.conf.MacroBaseConf;
 import macrobase.conf.MacroBaseDefaults;
 import macrobase.datamodel.Datum;
+import macrobase.util.TrainTestSpliter;
 import org.apache.commons.math3.linear.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,12 +31,18 @@ public class ExpectMaxGMM extends BatchMixtureModel {
 
     @Override
     public void train(List<Datum> data) {
-        trainEM(data);
+        if ( trainTestSplit > 0 && trainTestSplit < 1) {
+            TrainTestSpliter splitter = new TrainTestSpliter(data, trainTestSplit, conf.getRandom());
+            trainTestEM(splitter.getTrainData(), splitter.getTestData());
+        } else {
+            trainTestEM(data, data);
+        }
     }
 
-    private void trainEM(List<Datum> data) {
-        int N = data.size();
-        int dimensions = data.get(0).getMetrics().getDimension();
+    private void trainTestEM(List<Datum> trainData, List<Datum> testData) {
+        int N = trainData.size();
+        log.debug("N = {}", N);
+        int dimensions = trainData.get(0).getMetrics().getDimension();
         // 1. Initialize the means and covariances and mixing coefficients,
         //    and evaluate the initial value of the log likelihood.
         mu = new ArrayList<>(this.K);
@@ -49,7 +56,7 @@ public class ExpectMaxGMM extends BatchMixtureModel {
         // Picking points uniformly does not work, because it sometimes leads
         // to a local maximum in EM optimization where two cluster are replaces with
         // twice the cluster that represents both.
-        mu = this.gonzalezInitializeMixtureCenters(data, this.K, conf.getRandom());
+        mu = this.gonzalezInitializeMixtureCenters(trainData, this.K, conf.getRandom());
         for (int k = 0; k < K; k++) {
             sigma.add(MatrixUtils.createRealIdentityMatrix(dimensions));
             mixtureDistributions.add(new MultivariateNormal(mu.get(k), sigma.get(k)));
@@ -58,14 +65,14 @@ public class ExpectMaxGMM extends BatchMixtureModel {
 
         // EM algorithm;
         double logLikelihood = -Double.MAX_VALUE;
-        for (int iteration = 0; ; iteration++) {
+        for (int iteration = 0; iteration < maxIterationsToConverge; iteration++) {
             // 2. E step. Evaluate the responsibilities using the current parameter values.
             double[][] gamma = new double[N][K];
             double[] clusterWeight = new double[N];  // N_k (Bishop)
             for (int n = 0; n < N; n++) {
                 double normalizingConstant = 0;
                 for (int k = 0; k < K; k++) {
-                    gamma[n][k] = phi[k] * mixtureDistributions.get(k).density(data.get(n).getMetrics());
+                    gamma[n][k] = phi[k] * mixtureDistributions.get(k).density(trainData.get(n).getMetrics());
                     normalizingConstant += gamma[n][k];
                 }
                 for (int k = 0; k < K; k++) {
@@ -78,13 +85,13 @@ public class ExpectMaxGMM extends BatchMixtureModel {
             for (int k = 0; k < K; k++) {
                 RealVector newMu = new ArrayRealVector(dimensions);
                 for (int n = 0; n < N; n++) {
-                    newMu = newMu.add(data.get(n).getMetrics().mapMultiply(gamma[n][k]));
+                    newMu = newMu.add(trainData.get(n).getMetrics().mapMultiply(gamma[n][k]));
                 }
                 newMu = newMu.mapDivide(clusterWeight[k]);
                 RealMatrix newSigma = new BlockRealMatrix(dimensions, dimensions);
                 mu.set(k, newMu);
                 for (int n = 0; n < N; n++) {
-                    RealVector _diff = data.get(n).getMetrics().subtract(newMu);
+                    RealVector _diff = trainData.get(n).getMetrics().subtract(newMu);
                     newSigma = newSigma.add(_diff.outerProduct(_diff).scalarMultiply(gamma[n][k]));
                 }
                 newSigma = newSigma.scalarMultiply(1. / clusterWeight[k]);
@@ -99,11 +106,12 @@ public class ExpectMaxGMM extends BatchMixtureModel {
 
             double oldLogLikelihood = logLikelihood;
             logLikelihood = 0;
-            for (int n = 0; n < N; n++) {
-                logLikelihood += score(data.get(n));
+            for (int n = 0; n < testData.size(); n++) {
+                logLikelihood += score(testData.get(n));
             }
+            logLikelihood /= testData.size();
 
-            log.debug("log likelihood after iteration {} is {}", iteration, logLikelihood);
+            log.debug("per point log likelihood after iteration {} is {}", iteration, logLikelihood);
 
             log.debug("cluster likelihoods are: {}", phi);
             log.debug("cluster centers are at {}", mu);
@@ -130,11 +138,6 @@ public class ExpectMaxGMM extends BatchMixtureModel {
             probability += phi[k] * mixtureDistributions.get(k).density(datum.getMetrics());
         }
         return Math.log(probability);
-    }
-
-    @Override
-    public double getZScoreEquivalent(double zscore) {
-        return 0;
     }
 
     @Override

--- a/src/main/java/macrobase/analysis/stats/mixture/MultiComponents.java
+++ b/src/main/java/macrobase/analysis/stats/mixture/MultiComponents.java
@@ -1,8 +1,11 @@
 package macrobase.analysis.stats.mixture;
 
 import org.apache.commons.math3.special.Gamma;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MultiComponents implements MixingComponents {
+    private static final Logger log = LoggerFactory.getLogger(MultiComponents.class);
 
     private double priorAlpha;
     private double[] coeffs;
@@ -43,8 +46,10 @@ public class MultiComponents implements MixingComponents {
 
     public void moveNatural(double[][] r, double pace, double portion) {
         double[] clusterWeight = VariationalInference.calculateClusterWeights(r);
+        sumCoeffs = 0;
         for (int k = 0; k < K; k++) {
             coeffs[k] = VariationalInference.step(coeffs[k], priorAlpha + portion * clusterWeight[k], pace);
+            sumCoeffs += coeffs[k];
         }
     }
 

--- a/src/main/java/macrobase/analysis/stats/mixture/StochVarDPGMM.java
+++ b/src/main/java/macrobase/analysis/stats/mixture/StochVarDPGMM.java
@@ -1,6 +1,7 @@
 package macrobase.analysis.stats.mixture;
 
 import macrobase.conf.MacroBaseConf;
+import macrobase.conf.MacroBaseDefaults;
 import macrobase.datamodel.Datum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,19 +10,23 @@ import java.util.List;
 
 public class StochVarDPGMM extends DPGMM {
     private static final Logger log = LoggerFactory.getLogger(StochVarDPGMM.class);
+    private final int desiredMinibatchSize;
+    private final double delay;
+    private final double forgettingRate;
 
     public StochVarDPGMM(MacroBaseConf conf) {
         super(conf);
+        desiredMinibatchSize = conf.getInt(MacroBaseConf.SVI_MINIBATCH_SIZE, MacroBaseDefaults.SVI_MINIBATCH_SIZE);
+        delay = conf.getDouble(MacroBaseConf.SVI_DELAY, MacroBaseDefaults.SVI_DELAY);
+        forgettingRate = conf.getDouble(MacroBaseConf.SVI_FORGETTING_RATE, MacroBaseDefaults.SVI_FORGETTING_RATE);
     }
-    @Override
-    public void train(List<Datum> data) {
-        // 0. Initialize all approximating factors
-        log.debug("training locally");
-        clusters = new NormalWishartClusters(T, data.get(0).getMetrics().getDimension());
-        clusters.initializeBaseForDP(data);
-        clusters.initializeAtomsForDP(data, conf.getRandom());
 
-        log.debug("actual training");
-        VariationalInference.trainStochastic(this, data, mixingComponents, clusters, 7000, 0.01, 0.0);
+    @Override
+    public void trainTest(List<Datum> trainData, List<Datum> testData) {
+        // 0. Initialize all approximating factors
+        clusters = new NormalWishartClusters(T, trainData.get(0).getMetrics().getDimension());
+        clusters.initializeBaseForDP(trainData);
+        clusters.initializeAtomsForDP(trainData, initialClusterCentersFile, conf.getRandom());
+        VariationalInference.trainTestStochastic(this, trainData, testData, mixingComponents, clusters, desiredMinibatchSize, delay, forgettingRate);
     }
 }

--- a/src/main/java/macrobase/analysis/transform/BatchMixtureCoeffTransform.java
+++ b/src/main/java/macrobase/analysis/transform/BatchMixtureCoeffTransform.java
@@ -4,6 +4,8 @@ import macrobase.analysis.stats.mixture.BatchMixtureModel;
 import macrobase.conf.ConfigurationException;
 import macrobase.conf.MacroBaseConf;
 import macrobase.datamodel.Datum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -13,6 +15,7 @@ import java.util.List;
  * data belonging to different clusters.
  */
 public class BatchMixtureCoeffTransform extends BatchScoreFeatureTransform {
+    private static final Logger log = LoggerFactory.getLogger(BatchMixtureCoeffTransform.class);
     protected BatchMixtureModel mixtureModel;
 
     public BatchMixtureCoeffTransform(MacroBaseConf conf, MacroBaseConf.TransformType transformType) throws ConfigurationException {
@@ -22,10 +25,13 @@ public class BatchMixtureCoeffTransform extends BatchScoreFeatureTransform {
 
     @Override
     public void consume(List<Datum> records) {
+        long startMs = System.currentTimeMillis();
         mixtureModel.train(records);
         for (Datum d : records) {
             output.add(new Datum(d, mixtureModel.getClusterProbabilities(d)));
         }
+        long endMs = System.currentTimeMillis();
+        log.debug("mixture model took: {} milliseconds", endMs - startMs);
     }
 
     public BatchMixtureModel getMixtureModel() {

--- a/src/main/java/macrobase/analysis/transform/BeforeAfterDumpingBatchScoreFeatureTransform.java
+++ b/src/main/java/macrobase/analysis/transform/BeforeAfterDumpingBatchScoreFeatureTransform.java
@@ -34,7 +34,7 @@ public class BeforeAfterDumpingBatchScoreFeatureTransform extends FeatureTransfo
 
         if (this.dumpFilename != null) {
             List<MetricsAndMetrics> beforeAndAfter = new ArrayList<>(initalRecords.size());
-            for (int i = 0; i < initalRecords.size(); i++) {
+            for (int i = 0; i < transferredRecords.size(); i++) {
                 beforeAndAfter.add(new MetricsAndMetrics(initalRecords.get(i).getMetrics(), transferredRecords.get(i).getMetrics()));
             }
             JsonUtils.tryToDumpAsJson(beforeAndAfter, this.dumpFilename);

--- a/src/main/java/macrobase/analysis/transform/GridDumpingBatchScoreTransform.java
+++ b/src/main/java/macrobase/analysis/transform/GridDumpingBatchScoreTransform.java
@@ -9,10 +9,13 @@ import macrobase.datamodel.Datum;
 import macrobase.diagnostics.JsonUtils;
 import macrobase.diagnostics.ScoreDumper;
 import macrobase.util.AlgebraUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class GridDumpingBatchScoreTransform extends FeatureTransform {
+    private static final Logger log = LoggerFactory.getLogger(GridDumpingBatchScoreTransform.class);
 
     private final String dumpFilename;
     private final Integer dimensionsPerGrid;
@@ -25,6 +28,7 @@ public class GridDumpingBatchScoreTransform extends FeatureTransform {
         this.dumpMixtureComponents = conf.getString(MacroBaseConf.DUMP_MIXTURE_COMPONENTS, MacroBaseDefaults.DUMP_MIXTURE_COMPONENTS);
         this.underlyingTransform = batchScoreFeatureTransform;
     }
+
     @Override
     public void initialize() throws Exception {
 
@@ -33,6 +37,7 @@ public class GridDumpingBatchScoreTransform extends FeatureTransform {
     @Override
     public void consume(List<Datum> records) throws Exception {
         underlyingTransform.consume(records);
+        log.debug("dumping");
         if (dumpFilename != null) {
             BatchTrainScore batchTrainScore = underlyingTransform.getBatchTrainScore();
             ScoreDumper.tryToDumpScoredGrid(batchTrainScore, AlgebraUtils.getBoundingBox(records), dimensionsPerGrid, dumpFilename);

--- a/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -48,6 +48,9 @@ public class MacroBaseConf extends Configuration {
     public static final String ITERATIVE_PROGRESS_CUTOFF_RATIO = "macrobase.analysis.stat.iterative.improvementCutoffRatio";
     public static final String DPM_TRUNCATING_PARAMETER = "macrobase.analysis.stat.dpm.truncatingParameter";
     public static final String DPM_CONCENTRATION_PARAMETER = "macrobase.analysis.stat.dpm.concentrationParameter";
+    public static final String SVI_DELAY = "macrobase.analysis.stat.svi.delay";
+    public static final String SVI_FORGETTING_RATE = "macrobase.analysis.stat.svi.forgettingRate";
+    public static final String SVI_MINIBATCH_SIZE = "macrobase.analysis.stat.svi.minibatchSize";
 
     // Algorithm to use when choosing the bandwidth for the given data.
     public static final String KDE_BANDWIDTH_ALGORITHM = "macrobase.analysis.kde.bandwidthAlgorithm";
@@ -83,7 +86,7 @@ public class MacroBaseConf extends Configuration {
 
     public static final String CSV_INPUT_FILE = "macrobase.loader.csv.file";
     public static final String CSV_COMPRESSION = "macrobase.loader.csv.compression";
-    
+
     public static final String CONTEXTUAL_API = "macrobase.analysis.contextual.api";
     public static final String CONTEXTUAL_API_OUTLIER_PREDICATES = "macrobase.analysis.contextual.api.outlierPredicates";
     public static final String CONTEXTUAL_DISCRETE_ATTRIBUTES = "macrobase.analysis.contextual.discreteAttributes";
@@ -105,7 +108,8 @@ public class MacroBaseConf extends Configuration {
     public static final String NUM_SCORE_GRID_POINTS_PER_DIMENSION = "macrobase.diagnostic.gridPointsPerDimension";
     public static final String SCORED_DATA_FILE = "macrobase.diagnostic.scoreDataFile";
     public static final String DUMP_MIXTURE_COMPONENTS = "macrobase.diagnostic.dumpMixtureComponents";
-    public static final String MIXTURE_CENTERS_FILE = "macrobase.analysis.stat.mixtures.initalClusters";
+    public static final String MIXTURE_CENTERS_FILE = "macrobase.analysis.stat.mixtures.initialClusters";
+    public static final String TRAIN_TEST_SPLIT = "macrobase.analysis.stat.trainTestSplit";
 
     private final DatumEncoder datumEncoder;
 
@@ -158,7 +162,7 @@ public class MacroBaseConf extends Configuration {
         findAllContextualOutliers,
         findContextsGivenOutlierPredicate,
     }
-    
+
     public Random getRandom() {
         Long seed = getLong(RANDOM_SEED, null);
         if (seed != null) {
@@ -354,9 +358,9 @@ public class MacroBaseConf extends Configuration {
         }
         return TransformType.valueOf(_conf.get(TRANSFORM_TYPE));
     }
-    
+
     public ContextualAPI getContextualAPI() throws ConfigurationException {
-        if(!_conf.containsKey(CONTEXTUAL_API)) {
+        if (!_conf.containsKey(CONTEXTUAL_API)) {
             return MacroBaseDefaults.CONTEXTUAL_API;
         }
         return ContextualAPI.valueOf(_conf.get(CONTEXTUAL_API));

--- a/src/main/java/macrobase/conf/MacroBaseDefaults.java
+++ b/src/main/java/macrobase/conf/MacroBaseDefaults.java
@@ -102,4 +102,9 @@ public class MacroBaseDefaults {
     public static final String SCORED_DATA_FILE = null;
     public static final Integer NUM_SCORE_GRID_POINTS_PER_DIMENSION = 1000;
     public static final String DUMP_MIXTURE_COMPONENTS = null;
+    public static final Integer SVI_MINIBATCH_SIZE = 10000;
+    public static final Double SVI_DELAY = 1.0;
+    public static final Double SVI_FORGETTING_RATE = 0.9;
+    public static final Double TRAIN_TEST_SPLIT = -1.0; // Train and test on the entire dataset while training
+    public static final Double KDE_PROPORTION_OF_DATA_TO_USE = 0.01;
 }

--- a/src/main/java/macrobase/runtime/command/MacroBasePipelineCommand.java
+++ b/src/main/java/macrobase/runtime/command/MacroBasePipelineCommand.java
@@ -3,16 +3,14 @@ package macrobase.runtime.command;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 import macrobase.MacroBase;
-import macrobase.analysis.pipeline.BasicBatchedPipeline;
 import macrobase.analysis.pipeline.Pipeline;
 import macrobase.analysis.result.AnalysisResult;
 import macrobase.conf.MacroBaseConf;
 import net.sourceforge.argparse4j.inf.Namespace;
-
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 public class MacroBasePipelineCommand extends ConfiguredCommand<MacroBaseConf> {
     private static final Logger log = LoggerFactory.getLogger(MacroBasePipelineCommand.class);
@@ -29,14 +27,14 @@ public class MacroBasePipelineCommand extends ConfiguredCommand<MacroBaseConf> {
         Class c = Class.forName(configuration.getString(MacroBaseConf.PIPELINE_NAME));
         Object ao = c.newInstance();
 
-        if(!(ao instanceof Pipeline)) {
+        if (!(ao instanceof Pipeline)) {
             log.error("{} is not an instance of Pipeline! Exiting...");
             return;
         }
 
         List<AnalysisResult> results = ((Pipeline) ao).initialize(configuration).run();
 
-        for(AnalysisResult result: results) {
+        for (AnalysisResult result : results) {
             if (result.getItemSets().size() > 1000) {
                 log.warn("Very large result set! {}; truncating to 1000", result.getItemSets().size());
                 result.setItemSets(result.getItemSets().subList(0, 1000));

--- a/src/main/java/macrobase/util/TrainTestSpliter.java
+++ b/src/main/java/macrobase/util/TrainTestSpliter.java
@@ -1,0 +1,42 @@
+package macrobase.util;
+
+import macrobase.datamodel.Datum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class TrainTestSpliter {
+    private static final Logger log = LoggerFactory.getLogger(TrainTestSpliter.class);
+    private final List<Datum> trainData;
+    private final List<Datum> testData;
+
+    public TrainTestSpliter(List<Datum> data, double trainRatio, Random rand) {
+
+        List<Datum> trainingData = new ArrayList<>((int) (data.size() * trainRatio));
+        List<Datum> testData = new ArrayList<>((int) (data.size() * (1 - trainRatio)));
+
+        log.debug("nextDouble() {}", rand.nextDouble());
+        for (Datum d : data) {
+            if (rand.nextDouble() < trainRatio ) {
+                trainingData.add(d);
+            } else {
+                testData.add(d);
+            }
+        }
+        log.debug("training points = {}", trainingData.size());
+        log.debug("test points = {}", testData.size());
+        this.trainData = trainingData;
+        this.testData = testData;
+    }
+
+    public List<Datum> getTrainData() {
+        return trainData;
+    }
+
+    public List<Datum> getTestData() {
+        return testData;
+    }
+}

--- a/src/test/java/macrobase/analysis/stats/distribution/MixtureTest.java
+++ b/src/test/java/macrobase/analysis/stats/distribution/MixtureTest.java
@@ -1,0 +1,42 @@
+package macrobase.analysis.stats.distribution;
+
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.BlockRealMatrix;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class MixtureTest {
+    private static final Logger log = LoggerFactory.getLogger(MixtureTest.class);
+    @Test
+    public void nonZeroScoreTest() {
+        List<MultivariateDistribution> listDist = new ArrayList<>(3);
+        double[] weights = {2. / 7, 3. / 7, 2. / 7};
+        double[][] distData = {
+                {1.5, 2}, {0.5, 0.4, 0.4, 0.5}, {2000},
+                {2, 0}, {0.3, 0, 0, 0.6}, {3000},
+                {4.5, 1}, {0.9, 0.2, 0.2, 0.3}, {2000}};
+        for (int i = 0; i < distData.length; i += 3) {
+            RealVector mean = new ArrayRealVector(distData[i + 0]);
+            double[][] covArray = new double[2][2];
+            covArray[0] = Arrays.copyOfRange(distData[i + 1], 0, 2);
+            covArray[1] = Arrays.copyOfRange(distData[i + 1], 2, 4);
+            RealMatrix cov = new BlockRealMatrix(covArray);
+            listDist.add(new MultivariateNormal(mean, cov));
+        }
+
+        Mixture mixture = new Mixture(listDist, weights);
+
+        assertEquals(0.155359, mixture.density(new ArrayRealVector(distData[0])), 1e-6);
+        assertEquals(0.162771, mixture.density(new ArrayRealVector(distData[3])), 1e-6);
+        assertEquals(0.094819, mixture.density(new ArrayRealVector(distData[6])), 1e-6);
+    }
+}

--- a/src/test/java/macrobase/analysis/stats/mixture/ExpectMaxGMMTest.java
+++ b/src/test/java/macrobase/analysis/stats/mixture/ExpectMaxGMMTest.java
@@ -25,6 +25,7 @@ public class ExpectMaxGMMTest {
      */
     public void bivariateWellSeparatedNormalTest() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
+                .set(MacroBaseConf.RANDOM_SEED, 2)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "EM_GMM")
                 .set(MacroBaseConf.NUM_MIXTURES, 3)
                 .set(MacroBaseConf.DATA_LOADER_TYPE, "CSV_LOADER")
@@ -92,6 +93,7 @@ public class ExpectMaxGMMTest {
      */
     public void bivariateOkSeparatedNormalTest() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
+                .set(MacroBaseConf.RANDOM_SEED, 152)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "EM_GMM")
                 .set(MacroBaseConf.NUM_MIXTURES, 3)
                 .set(MacroBaseConf.DATA_LOADER_TYPE, "CSV_LOADER")

--- a/src/test/java/macrobase/analysis/stats/mixture/StochVarDPGMMTest.java
+++ b/src/test/java/macrobase/analysis/stats/mixture/StochVarDPGMMTest.java
@@ -29,6 +29,7 @@ public class StochVarDPGMMTest {
     public void bivariateWellSeparatedNormalTest() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
                 .set(MacroBaseConf.RANDOM_SEED, 8)
+                .set(MacroBaseConf.SVI_FORGETTING_RATE, 0.01)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "SVI_DPGMM")
                 .set(MacroBaseConf.DPM_TRUNCATING_PARAMETER, 10)
                 .set(MacroBaseConf.DPM_CONCENTRATION_PARAMETER, 0.3)
@@ -67,12 +68,15 @@ public class StochVarDPGMMTest {
                 {{0.9, 0.2}, {0.2, 0.3}},
         };
 
+        log.debug("weights: {}", dpgmm.getClusterProportions());
+
 
         ExpectMaxGMM gmm = new ExpectMaxGMM(conf);
         gmm.train(data);
         List<RealVector> emMeans = gmm.getClusterCenters();
         List<RealMatrix> emCovariances = gmm.getClusterCovariances();
 
+        log.debug("cov: {}", calculatedCovariances);
         for (int i = 0; i < 3; i++) {
             boolean identified = false;
             for (int j = 0; j < 3; j++) {
@@ -121,6 +125,7 @@ public class StochVarDPGMMTest {
     public void bivariateOkSeparatedNormalTest() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
                 .set(MacroBaseConf.RANDOM_SEED, 2)
+                .set(MacroBaseConf.SVI_FORGETTING_RATE, 0.01)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "SVI_DPGMM")
                 .set(MacroBaseConf.DPM_TRUNCATING_PARAMETER, 10)
                 .set(MacroBaseConf.MAX_ITERATIONS_TO_CONVERGE, 15)

--- a/src/test/java/macrobase/analysis/stats/mixture/StochVarFiniteGMMTest.java
+++ b/src/test/java/macrobase/analysis/stats/mixture/StochVarFiniteGMMTest.java
@@ -30,6 +30,7 @@ public class StochVarFiniteGMMTest {
         MacroBaseConf conf = new MacroBaseConf()
                 .set(MacroBaseConf.RANDOM_SEED, 44)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "SVI_GMM")
+                .set(MacroBaseConf.SVI_FORGETTING_RATE, 0.01)
                 .set(MacroBaseConf.NUM_MIXTURES, 3)
                 .set(MacroBaseConf.MIXTURE_CENTERS_FILE, "src/test/resources/data/3gaussians-700.points-centers.json")
                 .set(MacroBaseConf.DATA_LOADER_TYPE, "CSV_LOADER")
@@ -120,6 +121,7 @@ public class StochVarFiniteGMMTest {
     public void bivariateOkSeparatedNormalTest() throws Exception {
         MacroBaseConf conf = new MacroBaseConf()
                 .set(MacroBaseConf.RANDOM_SEED, 4)
+                .set(MacroBaseConf.SVI_FORGETTING_RATE, 0.01)
                 .set(MacroBaseConf.TRANSFORM_TYPE, "SVI_GMM")
                 .set(MacroBaseConf.MAX_ITERATIONS_TO_CONVERGE, 20)
                 .set(MacroBaseConf.NUM_MIXTURES, 3)

--- a/src/test/java/macrobase/analysis/stats/mixture/VarGMMTest.java
+++ b/src/test/java/macrobase/analysis/stats/mixture/VarGMMTest.java
@@ -1,0 +1,86 @@
+package macrobase.analysis.stats.mixture;
+
+import macrobase.analysis.stats.distribution.MultivariateNormal;
+import macrobase.conf.MacroBaseConf;
+import macrobase.datamodel.Datum;
+import macrobase.ingest.CSVIngester;
+import macrobase.util.Drainer;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.BlockRealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class VarGMMTest {
+
+    @Test
+    /**
+     * Tests Gaussian Mixture Model on a three not so well separated clusters.
+     */
+    public void bivariateOkSeparatedNormalTest() throws Exception {
+        MacroBaseConf conf = new MacroBaseConf()
+                .set(MacroBaseConf.RANDOM_SEED, 0)
+                .set(MacroBaseConf.TRANSFORM_TYPE, "MEAN_FIELD_GMM")
+                .set(MacroBaseConf.NUM_MIXTURES, 3)
+                .set(MacroBaseConf.MAX_ITERATIONS_TO_CONVERGE, 15)
+                .set(MacroBaseConf.ITERATIVE_PROGRESS_CUTOFF_RATIO, 0.001)
+                .set(MacroBaseConf.DATA_LOADER_TYPE, "CSV_LOADER")
+                .set(MacroBaseConf.TRAIN_TEST_SPLIT, 0.9)
+                .set(MacroBaseConf.CSV_COMPRESSION, CSVIngester.Compression.GZIP)
+                .set(MacroBaseConf.CSV_INPUT_FILE, "src/test/resources/data/3gaussians-7000points.csv.gz")
+                .set(MacroBaseConf.HIGH_METRICS, "XX, YY")
+                .set(MacroBaseConf.LOW_METRICS, "")
+                .set(MacroBaseConf.ATTRIBUTES, "");
+        List<Datum> data = Drainer.drainIngest(conf);
+        int totalPoints = 7000;
+        assertEquals(totalPoints, data.size());
+
+        double[][] clusterMeans = {
+                {1.5, 2},
+                {2, 0},
+                {4.5, 1},
+        };
+        List<RealVector> vectorClusterMeans = new ArrayList<>(3);
+        for (int k = 0; k < 3; k++) {
+            vectorClusterMeans.add(new ArrayRealVector(clusterMeans[k]));
+        }
+        double[][][] clusterCovariances = {
+                {{0.5, 0.4}, {0.4, 0.5}},
+                {{0.3, 0}, {0, 0.6}},
+                {{0.9, 0.2}, {0.2, 0.3}},
+        };
+
+        double[] clusterWeights = {
+                2000,
+                3000,
+                2000,
+        };
+
+        FiniteGMM finiteGMM = new FiniteGMM(conf);
+        finiteGMM.train(data);
+
+        List<MultivariateNormal> normals = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            normals.add(new MultivariateNormal(vectorClusterMeans.get(i), new BlockRealMatrix(clusterCovariances[i])));
+        }
+        Random rand = conf.getRandom();
+        for (int i = 0; i < 10; i++) {
+            Datum d = data.get(rand.nextInt(totalPoints));
+            double density = 0;
+            for (int j = 0; j < 3; j++) {
+                density += clusterWeights[j] / totalPoints * normals.get(j).density(d.getMetrics());
+            }
+            // Finite Model takes longer to converge, and since we are limiting num
+            // iterations, take a conservative limit on deviation.
+            assertEquals(density, Math.exp(finiteGMM.score(d)), 0.06);
+        }
+
+        double[] farPoint = {1000, 10000};
+        assertEquals(finiteGMM.ZERO_LOG_SCORE, finiteGMM.score(new Datum(new ArrayList<Integer>(), new ArrayRealVector(farPoint))), 1e-9);
+    }
+}

--- a/src/test/java/macrobase/analysis/stats/mixture/VariationalInferenceTest.java
+++ b/src/test/java/macrobase/analysis/stats/mixture/VariationalInferenceTest.java
@@ -1,0 +1,36 @@
+package macrobase.analysis.stats.mixture;
+
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.BlockRealMatrix;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class VariationalInferenceTest {
+    private static final Logger log = LoggerFactory.getLogger(VariationalInferenceTest.class);
+
+    @Test
+    public void sviStepTest() {
+        assertEquals(0.9, VariationalInference.step(0, 1, 0.9), 1e-9);
+        assertEquals(19.0, VariationalInference.step(10, 20, 0.9), 1e-9);
+        assertEquals(12.0, VariationalInference.step(10, 20, 0.2), 1e-9);
+
+        double[] array1 = {1, 2, 6};
+        double[] array2 = {2, 3, 8};
+        double[] array3 = {5, 6, 14};
+        RealVector start = new ArrayRealVector(array1);
+        RealVector end = new ArrayRealVector(array3);
+        assertEquals(new ArrayRealVector(array2), VariationalInference.step(start, end, 0.25));
+
+        double[][] matrix1 = {{1, 2}, {3, 10}};
+        double[][] matrix2 = {{2, 6}, {3, 100}};
+        double[][] matrix3 = {{5, 18}, {3, 370}};
+        RealMatrix s = new BlockRealMatrix(matrix1);
+        RealMatrix e = new BlockRealMatrix(matrix3);
+        assertEquals(new BlockRealMatrix(matrix2), VariationalInference.step(s, e, 0.25));
+    }
+}

--- a/src/test/java/macrobase/diagnostic/DiagnosticApplication.java
+++ b/src/test/java/macrobase/diagnostic/DiagnosticApplication.java
@@ -4,12 +4,16 @@ import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import macrobase.conf.MacroBaseConf;
+import macrobase.diagnostic.tasks.HeldOutDataLogLikelihoodCalc;
 import macrobase.diagnostic.tasks.ScoreDumpDiagnostic;
+import macrobase.diagnostic.tasks.TrueDensityISECalculator;
 
 public class DiagnosticApplication extends Application<MacroBaseConf> {
     @Override
     public void initialize(Bootstrap<MacroBaseConf> bootstrap) {
+        bootstrap.addCommand(new TrueDensityISECalculator());
         bootstrap.addCommand(new ScoreDumpDiagnostic());
+        bootstrap.addCommand(new HeldOutDataLogLikelihoodCalc());
     }
 
     @Override

--- a/src/test/java/macrobase/diagnostic/tasks/HeldOutDataLogLikelihoodCalc.java
+++ b/src/test/java/macrobase/diagnostic/tasks/HeldOutDataLogLikelihoodCalc.java
@@ -1,0 +1,90 @@
+package macrobase.diagnostic.tasks;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import macrobase.analysis.pipeline.BasePipeline;
+import macrobase.analysis.pipeline.Pipeline;
+import macrobase.analysis.result.AnalysisResult;
+import macrobase.analysis.stats.BatchTrainScore;
+import macrobase.analysis.summary.itemset.result.ItemsetResult;
+import macrobase.analysis.transform.BatchScoreFeatureTransform;
+import macrobase.conf.MacroBaseConf;
+import macrobase.datamodel.Datum;
+import macrobase.ingest.DataIngester;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+public class HeldOutDataLogLikelihoodCalc extends ConfiguredCommand<MacroBaseConf> {
+    private static final Logger log = LoggerFactory.getLogger(TrueDensityISECalculator.class);
+    public static final String HOLD_OUT_PERCENTAGE = "macrobase.diagnostic.holdOutPercentage";
+
+    public HeldOutDataLogLikelihoodCalc() {
+        super("loglike", "Calculate log likelihood on held out data.");
+    }
+
+    @Override
+    protected void run(Bootstrap<MacroBaseConf> bootstrap, Namespace namespace, MacroBaseConf macroBaseConf) throws Exception {
+        Pipeline task = new LogeLikelihoodCalculator();
+        task.initialize(macroBaseConf);
+        task.run();
+    }
+
+    private class LogeLikelihoodCalculator extends BasePipeline {
+        @Override
+        public List<AnalysisResult> run() throws Exception {
+            DataIngester ingester = conf.constructIngester();
+
+            List<Datum> data = ingester.getStream().drain();
+
+            long startMs = System.currentTimeMillis();
+            double keepRatio = conf.getDouble(HOLD_OUT_PERCENTAGE, 0.1);
+
+            List<Datum> trainingData = new ArrayList<>((int) (data.size() * (1 - keepRatio)));
+            List<Datum> testData = new ArrayList<>((int) (data.size() * keepRatio));
+
+            Random rand = conf.getRandom();
+            log.debug("nextDouble() {}", rand.nextDouble());
+            for (Datum d : data) {
+                if (rand.nextDouble() < keepRatio) {
+                    testData.add(d);
+                } else {
+                    trainingData.add(d);
+                }
+            }
+            log.debug("training points = {}", trainingData.size());
+            log.debug("test points = {}", testData.size());
+
+            long loadEndMs = System.currentTimeMillis();
+
+            BatchScoreFeatureTransform batchTransform = new BatchScoreFeatureTransform(conf, conf.getTransformType());
+
+            batchTransform.consume(trainingData);
+
+            BatchTrainScore batchTrainScore = batchTransform.getBatchTrainScore();
+
+            double overallScore = 0;
+            for (Datum d : testData) {
+                overallScore += batchTrainScore.score(d);
+            }
+            overallScore /= testData.size();
+
+            log.debug("Per point score: {}", overallScore);
+            final long endMs = System.currentTimeMillis();
+            final long loadMs = loadEndMs - startMs;
+            final long totalMs = endMs - loadEndMs;
+
+            return Arrays.asList(new AnalysisResult(0,
+                    0,
+                    loadMs,
+                    totalMs,
+                    0,
+                    new ArrayList<ItemsetResult>()));
+        }
+    }
+}

--- a/src/test/java/macrobase/diagnostic/tasks/ScoreDumpDiagnostic.java
+++ b/src/test/java/macrobase/diagnostic/tasks/ScoreDumpDiagnostic.java
@@ -1,6 +1,5 @@
 package macrobase.diagnostic.tasks;
 
-import macrobase.util.Drainer;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.dropwizard.cli.ConfiguredCommand;
@@ -11,6 +10,7 @@ import macrobase.analysis.stats.BatchTrainScore;
 import macrobase.conf.MacroBaseConf;
 import macrobase.datamodel.Datum;
 import macrobase.ingest.DatumEncoder;
+import macrobase.util.Drainer;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/macrobase/diagnostic/tasks/TrueDensityISECalculator.java
+++ b/src/test/java/macrobase/diagnostic/tasks/TrueDensityISECalculator.java
@@ -1,0 +1,150 @@
+package macrobase.diagnostic.tasks;
+
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import macrobase.analysis.pipeline.BasePipeline;
+import macrobase.analysis.pipeline.stream.MBStream;
+import macrobase.analysis.result.AnalysisResult;
+import macrobase.analysis.stats.BatchTrainScore;
+import macrobase.analysis.stats.distribution.Mixture;
+import macrobase.analysis.stats.distribution.MultivariateDistribution;
+import macrobase.analysis.stats.distribution.MultivariateNormal;
+import macrobase.analysis.summary.itemset.result.ItemsetResult;
+import macrobase.analysis.transform.BatchScoreFeatureTransform;
+import macrobase.analysis.transform.FeatureTransform;
+import macrobase.conf.MacroBaseConf;
+import macrobase.conf.MacroBaseDefaults;
+import macrobase.datamodel.Datum;
+import macrobase.ingest.DataIngester;
+import macrobase.util.AlgebraUtils;
+import macrobase.util.DiagnosticsUtils;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.BlockRealMatrix;
+import org.apache.commons.math3.linear.RealMatrix;
+import org.apache.commons.math3.linear.RealVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TrueDensityISECalculator extends ConfiguredCommand<MacroBaseConf> {
+    private static final Logger log = LoggerFactory.getLogger(TrueDensityISECalculator.class);
+
+    public TrueDensityISECalculator() {
+        super("ise", "Dump true density related statistics.");
+    }
+
+    @Override
+    protected void run(Bootstrap<MacroBaseConf> bootstrap, Namespace namespace, MacroBaseConf macroBaseConf) throws Exception {
+        AMSETask task = new AMSETask();
+        task.initialize(macroBaseConf);
+        task.run();
+    }
+
+    private class AMSETask extends BasePipeline {
+        @Override
+        public List<AnalysisResult> run() throws Exception {
+            long startMs = System.currentTimeMillis();
+            DataIngester ingester = conf.constructIngester();
+
+            List<Datum> data = ingester.getStream().drain();
+            long loadEndMs = System.currentTimeMillis();
+
+            BatchScoreFeatureTransform batchTransform = new BatchScoreFeatureTransform(conf, conf.getTransformType());
+
+            List<MultivariateDistribution> listDist = new ArrayList<>(3);
+            double[] weights = new double[3];
+            double totalW = 0;
+            double[][] distData = {
+                    {1.5, 2}, {0.5, 0.4, 0.4, 0.5}, {50000},
+                    {2, 0}, {0.3, 0, 0, 0.6}, {30000},
+                    {4.5, 1}, {0.9, 0.2, 0.2, 0.3}, {20000}};
+            for (int i = 0; i < distData.length; i += 3) {
+                RealVector mean = new ArrayRealVector(distData[i + 0]);
+                double[][] covArray = new double[2][2];
+                covArray[0] = Arrays.copyOfRange(distData[i + 1], 0, 2);
+                covArray[1] = Arrays.copyOfRange(distData[i + 1], 2, 4);
+                RealMatrix cov = new BlockRealMatrix(covArray);
+                listDist.add(new MultivariateNormal(mean, cov));
+                weights[i / 3] = distData[i + 2][0];
+                totalW += weights[i / 3];
+            }
+            for (int i = 0; i < weights.length; i++) {
+                weights[i] /= totalW;
+            }
+
+            FeatureTransform amse = new TrueScoreExpDifferenceTransform(conf, batchTransform, new Mixture(listDist, weights));
+            amse.consume(data);
+
+            final long endMs = System.currentTimeMillis();
+            final long loadMs = loadEndMs - startMs;
+            final long totalMs = endMs - loadEndMs;
+
+            return Arrays.asList(new AnalysisResult(0,
+                    0,
+                    loadMs,
+                    totalMs,
+                    0,
+                    new ArrayList<ItemsetResult>()));
+        }
+    }
+
+    private class TrueScoreExpDifferenceTransform extends FeatureTransform {
+        private final MBStream<Datum> output = new MBStream<>();
+        private BatchScoreFeatureTransform underlyingTransform;
+        private MultivariateDistribution trueDistribution;
+        private BatchTrainScore underlyingBatchTrainScore;
+        private Integer pointsPerDim;
+
+        public TrueScoreExpDifferenceTransform(MacroBaseConf conf, BatchScoreFeatureTransform underlyingTransform, MultivariateDistribution trueDistribution) {
+            this.underlyingTransform = underlyingTransform;
+            this.trueDistribution = trueDistribution;
+            underlyingBatchTrainScore = underlyingTransform.getBatchTrainScore();
+            pointsPerDim = conf.getInt(MacroBaseConf.NUM_SCORE_GRID_POINTS_PER_DIMENSION, MacroBaseDefaults.NUM_SCORE_GRID_POINTS_PER_DIMENSION);
+        }
+
+        @Override
+        public void initialize() throws Exception {
+
+        }
+
+        @Override
+        public void consume(List<Datum> records) throws Exception {
+            List<Datum> initialRecords = records;
+            underlyingTransform.consume(records);
+
+            List<Datum> transferredRecords = underlyingTransform.getStream().drain();
+            output.add(transferredRecords);
+
+            double[][] boundaries = AlgebraUtils.getBoundingBox(initialRecords);
+            List<Datum> grid = DiagnosticsUtils.createGridFixedSize(boundaries, pointsPerDim);
+
+            double squaredSum = 0;
+
+            for (Datum d : grid) {
+                squaredSum += Math.pow(Math.exp(underlyingBatchTrainScore.score(d)) - trueDistribution.density(d.getMetrics()), 2);
+            }
+            log.debug("squaredSum: {}", squaredSum);
+
+            double areaPerPoint = 1;
+            for (double[] minMax : boundaries) {
+                areaPerPoint *= (minMax[1] - minMax[0]) / pointsPerDim;
+            }
+
+            log.debug("approximated Integral: {}", squaredSum * areaPerPoint);
+        }
+
+        @Override
+        public void shutdown() throws Exception {
+
+        }
+
+        @Override
+        public MBStream<Datum> getStream() throws Exception {
+            return output;
+        }
+    }
+}


### PR DESCRIPTION
This PR contributes the following

1. 2 tasks for diagnostics
  - `HeldOutDataLogLikelihoodCalc` which splits data into train/test parts and calculates test data log likelihood after training the model on train data
  - `TrueDensityISECalculator` calculates model density values with true density that was used to generate `src/test/resources/data/3gaussians-7000points.csv.gz`
2. allows user to control Stochastic Variational Inference (see docs/)
3. scripts for plotting convergence when training Variational models 