### PR TITLE
Rename AMC classes, use Quickselect for AMC.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,5 +191,10 @@
       <artifactId>JRI</artifactId>
       <version>0.9-7</version>
     </dependency>
+    <dependency>
+      <groupId>org.ddogleg</groupId>
+      <artifactId>ddogleg</artifactId>
+      <version>0.9</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounter.java
+++ b/src/main/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounter.java
@@ -30,8 +30,8 @@ import java.util.Map;
      4.) discard lower items, updating min if necessary
 
  */
-public class FastButBigSpaceSaving extends ApproximateCount {
-    private static final Logger log = LoggerFactory.getLogger(FastButBigSpaceSaving.class);
+public class AmortizedMaintenanceCounter extends ApproximateCount {
+    private static final Logger log = LoggerFactory.getLogger(AmortizedMaintenanceCounter.class);
 
     private HashMap<Integer, Double> counts = new HashMap<>();
     private double totalCount = 0;
@@ -39,7 +39,7 @@ public class FastButBigSpaceSaving extends ApproximateCount {
 
     private double prevEpochMaxEvicted = 0;
 
-    public FastButBigSpaceSaving(int maxStableSize) {
+    public AmortizedMaintenanceCounter(int maxStableSize) {
         this.maxStableSize = maxStableSize;
     }
 

--- a/src/main/java/macrobase/analysis/summary/itemset/ExponentiallyDecayingEmergingItemsets.java
+++ b/src/main/java/macrobase/analysis/summary/itemset/ExponentiallyDecayingEmergingItemsets.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 import macrobase.MacroBase;
 import macrobase.analysis.summary.count.ApproximateCount;
-import macrobase.analysis.summary.count.FastButBigSpaceSaving;
+import macrobase.analysis.summary.count.AmortizedMaintenanceCounter;
 import macrobase.analysis.summary.itemset.result.ItemsetResult;
 import macrobase.analysis.summary.itemset.result.ItemsetWithCount;
 import macrobase.datamodel.Datum;
@@ -56,8 +56,8 @@ public class ExponentiallyDecayingEmergingItemsets {
         this.exponentialDecayRate = exponentialDecayRate;
         this.attributeDimension = attributeDimension;
 
-        outlierCountSummary = new FastButBigSpaceSaving(outlierSummarySize);
-        inlierCountSummary = new FastButBigSpaceSaving(inlierSummarySize);
+        outlierCountSummary = new AmortizedMaintenanceCounter(outlierSummarySize);
+        inlierCountSummary = new AmortizedMaintenanceCounter(inlierSummarySize);
         outlierPatternSummary = new StreamingFPGrowth(minSupportOutlier);
     }
 

--- a/src/test/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounterTest.java
+++ b/src/test/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounterTest.java
@@ -1,18 +1,21 @@
 package macrobase.analysis.summary.count;
 
-/**
- * Created by pbailis on 12/24/15.
- */
 
+import com.google.common.base.Stopwatch;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
 public class AmortizedMaintenanceCounterTest {
+    private static final Logger log = LoggerFactory.getLogger(AmortizedMaintenanceCounterTest.class);
+
 
     @Test
     public void simpleTest() {
@@ -78,7 +81,7 @@ public class AmortizedMaintenanceCounterTest {
             assertEquals(trueCnt.get(cnt.getKey()), cnt.getValue(), N*EPSILON);
         }
 
-        assertEquals(0, ss.getCount(ITEMS+1), 1e-10);
+        assertEquals(0, ss.getCount(ITEMS + 1), 1e-10);
         int key = cnts.keySet().iterator().next();
         assertEquals(cnts.get(key), ss.getCount(key), 1e-10);
     }

--- a/src/test/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounterTest.java
+++ b/src/test/java/macrobase/analysis/summary/count/AmortizedMaintenanceCounterTest.java
@@ -12,11 +12,11 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-public class FastButBigSpaceSavingTest {
+public class AmortizedMaintenanceCounterTest {
 
     @Test
     public void simpleTest() {
-        FastButBigSpaceSaving ss = new FastButBigSpaceSaving(10);
+        AmortizedMaintenanceCounter ss = new AmortizedMaintenanceCounter(10);
         ss.observe(1);
         ss.observe(1);
         ss.observe(1);
@@ -34,7 +34,7 @@ public class FastButBigSpaceSavingTest {
 
     @Test
     public void overflowTest() {
-        FastButBigSpaceSaving ss = new FastButBigSpaceSaving(10);
+        AmortizedMaintenanceCounter ss = new AmortizedMaintenanceCounter(10);
 
         for (int i = 0; i < 10; ++i) {
             ss.observe(i);
@@ -53,7 +53,7 @@ public class FastButBigSpaceSavingTest {
         final int CAPACITY = 15;
         final double EPSILON = 1.0/CAPACITY;
 
-        FastButBigSpaceSaving ss = new FastButBigSpaceSaving(CAPACITY);
+        AmortizedMaintenanceCounter ss = new AmortizedMaintenanceCounter(CAPACITY);
 
         Random r = new Random(0);
 


### PR DESCRIPTION
Benchmarking locally shows 30-40% improvement in maintenance throughput when using quickselect instead of array sorting.