### PR TITLE
Close output stream.

### DIFF
--- a/src/main/java/macrobase/analysis/classify/DumpClassifier.java
+++ b/src/main/java/macrobase/analysis/classify/DumpClassifier.java
@@ -69,7 +69,7 @@ public class DumpClassifier extends OutlierClassifier {
 
     @Override
     public void shutdown() throws Exception {
-
+        out.close();
     }
 
     @Override

--- a/src/test/java/macrobase/analysis/classify/DumpClassifierTest.java
+++ b/src/test/java/macrobase/analysis/classify/DumpClassifierTest.java
@@ -66,6 +66,7 @@ public class DumpClassifierTest {
         dumper.consume(data);
 
         List<OutlierClassificationResult> results = dumper.getStream().drain();
+        dumper.shutdown();
 
         assertEquals(results.size(), data.size());
         OutlierClassificationResult first = results.get(0);


### PR DESCRIPTION
File cannot be deleted on Windows if you don't close the stream.