### PR TITLE
Google Monitoring API ingester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,5 +196,10 @@
       <artifactId>JRI</artifactId>
       <version>0.9-7</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-monitoring</artifactId>
+      <version>v3-rev6-1.22.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -98,6 +98,24 @@ public class MacroBaseConf extends Configuration {
     public static final String CSV_INPUT_FILE = "macrobase.loader.csv.file";
     public static final String CSV_COMPRESSION = "macrobase.loader.csv.compression";
 
+    // Queries given as a JSON string. Example:
+    // {
+    //   "queries": [
+    //     {
+    //       "project": "my-project",
+    //       "filter": "metric.type=\"custom.googleapis.com/test\"",
+    //       "alignmentPeriod": "300s",
+    //       "perSeriesAligner": "ALIGN_MEAN",
+    //       "crossSeriesReducer": "REDUCE_NONE",
+    //       "groupByFields": []
+    //     }
+    //   ]
+    // }
+    public static final String GOOGLE_MONITORING_QUERIES = "macrobase.loader.googlemonitoring.queries";
+    // Start and end times given in RFC3339 format. Example: "2016-08-08T12:00:00.0000Z"
+    public static final String GOOGLE_MONITORING_START_TIME = "macrobase.loader.googlemonitoring.startTime";
+    public static final String GOOGLE_MONITORING_END_TIME = "macrobase.loader.googlemonitoring.endTime";
+
     public static final String CONTEXTUAL_API = "macrobase.analysis.contextual.api";
     public static final String CONTEXTUAL_API_OUTLIER_PREDICATES = "macrobase.analysis.contextual.api.outlierPredicates";
     public static final String CONTEXTUAL_DISCRETE_ATTRIBUTES = "macrobase.analysis.contextual.discreteAttributes";
@@ -141,6 +159,8 @@ public class MacroBaseConf extends Configuration {
             return new MySQLIngester(this);
         } else if (ingesterType == DataIngesterType.CACHING_MYSQL_LOADER) {
             return new DiskCachingIngester(this, new MySQLIngester(this));
+        } else if (ingesterType == DataIngesterType.GOOGLE_MONITORING_LOADER) {
+            return new GoogleMonitoringIngester(this);
         }
 
         throw new ConfigurationException(String.format("Unknown data loader type: %s", ingesterType));
@@ -281,7 +301,8 @@ public class MacroBaseConf extends Configuration {
         POSTGRES_LOADER,
         CACHING_POSTGRES_LOADER,
         MYSQL_LOADER,
-        CACHING_MYSQL_LOADER
+        CACHING_MYSQL_LOADER,
+        GOOGLE_MONITORING_LOADER,
     }
 
 

--- a/src/main/java/macrobase/ingest/GoogleMonitoringIngester.java
+++ b/src/main/java/macrobase/ingest/GoogleMonitoringIngester.java
@@ -1,0 +1,340 @@
+package macrobase.ingest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.Lists;
+import com.google.api.services.monitoring.v3.Monitoring;
+import com.google.api.services.monitoring.v3.Monitoring.Projects;
+import com.google.api.services.monitoring.v3.MonitoringScopes;
+import com.google.api.services.monitoring.v3.model.ListTimeSeriesResponse;
+import com.google.api.services.monitoring.v3.model.Point;
+import com.google.api.services.monitoring.v3.model.TimeSeries;
+import io.dropwizard.jackson.Jackson;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import macrobase.analysis.pipeline.stream.MBStream;
+import macrobase.conf.ConfigurationException;
+import macrobase.conf.MacroBaseConf;
+import macrobase.datamodel.Datum;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.RealVector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.List;
+
+/**
+ * An ingester that fetches data from the Google Monitoring API.
+ *
+ * The ingester
+ *
+ * @see "https://cloud.google.com/monitoring/api/v3/"
+ */
+public class GoogleMonitoringIngester extends DataIngester {
+    private static final Logger log = LoggerFactory.getLogger(GoogleMonitoringIngester.class);
+
+    private MBStream<Datum> dataStream;
+
+    private boolean loaded = false;
+    private int pointsAdded = 0;
+    private int skippedTimeSeries = 0;
+    private int skippedPoints = 0;
+
+    public GoogleMonitoringIngester(MacroBaseConf conf) throws ConfigurationException, IOException {
+        super(conf);
+    }
+
+    @Override
+    public String getBaseQuery() {
+        return "";
+    }
+
+    @Override
+    public MBStream<Datum> getStream() throws Exception {
+        if (!loaded) {
+            QueryConf queryConf = getQueries(conf.getString(MacroBaseConf.GOOGLE_MONITORING_QUERIES));
+            String queryStart = conf.getString(MacroBaseConf.GOOGLE_MONITORING_START_TIME);
+            String queryEnd = conf.getString(MacroBaseConf.GOOGLE_MONITORING_END_TIME);
+
+            Set<String> allMetrics = new HashSet<>();
+            allMetrics.addAll(lowMetrics);
+            allMetrics.addAll(highMetrics);
+
+            if (allMetrics.size() == 0) {
+                throw new IllegalArgumentException("No metrics selected.");
+            }
+
+            // Record the attribute names.
+            int idx = 1;
+            Set<String> sortedAttributes = new TreeSet<>(attributes);
+            for (String a : sortedAttributes) {
+                conf.getEncoder().recordAttributeName(idx, a);
+                ++idx;
+            }
+
+            // Each TimeSeries returned has a unique set of metric/resource labels and a stream
+            // of values. Restructure the data to correlate by time so that we can ensure each Datum
+            // contains the requested metrics and attributes. To ensure that the streams returned
+            // by the API can be correlated by time, supply a per-series aligner.
+            //
+            // {timestamp, {attr_key, record}}
+            Map<String, Map<String, Record>> byTime = new TreeMap<>();
+
+            Monitoring client = buildClient();
+            for (QueryConf.Query query : queryConf.getQueries()) {
+                String pageToken = "";
+
+                do {
+                    Projects.TimeSeries.List request = client.projects().timeSeries()
+                        .list("projects/" + query.getProject())
+                        .setFilter(query.getFilter())
+                        .setIntervalStartTime(queryStart)
+                        .setIntervalEndTime(queryEnd)
+                        .setPageToken(pageToken)
+                        .setAggregationAlignmentPeriod(query.getAlignmentPeriod())
+                        .setAggregationPerSeriesAligner(query.getPerSeriesAligner())
+                        .setAggregationCrossSeriesReducer(query.getCrossSeriesReducer())
+                        .setAggregationGroupByFields(query.getGroupByFields());
+                    log.trace("Request: {}", request.toString());
+
+                    ListTimeSeriesResponse response = request.execute();
+                    log.trace("Response: {}", response.toPrettyString());
+
+                    processResponse(response, allMetrics, byTime);
+                    pageToken = response.getNextPageToken();
+                } while (pageToken != null && !pageToken.isEmpty());
+            }
+
+            dataStream = convertToStream(byTime);
+
+            log.info("Loaded {} points. Skipped {} TimeSeries and {} partial records.",
+                     pointsAdded, skippedTimeSeries, skippedPoints);
+            loaded = true;
+        }
+
+        return dataStream;
+    }
+
+    // Package scope to allow testing.
+    QueryConf getQueries(String queryJson) throws IOException {
+        ObjectMapper mapper = Jackson.newObjectMapper();
+        return mapper.readValue(queryJson, QueryConf.class);
+    }
+
+    // Package scope to allow testing.
+    void processResponse(ListTimeSeriesResponse response, Set<String> allMetrics,
+                         Map<String, Map<String, Record>> byTime) {
+
+        for (TimeSeries ts : response.getTimeSeries()) {
+            if (!allMetrics.contains(ts.getMetric().getType())) {
+                ++skippedTimeSeries;
+                continue;
+            }
+
+            // Extract attribute values from TimeSeries metric/resource labels. If some are
+            // missing, skip this time series. Keep the keys sorted so that they correspond
+            // to the attribute names recorded in the encoder.
+            Map<String, String> attrMap = new TreeMap<>();
+            boolean hasAllAttributes = true;
+
+            for (String a : attributes) {
+                String val = ts.getMetric().getLabels().get(a);
+                if (val == null) {
+                    val = ts.getResource().getLabels().get(a);
+                    if (val == null) {
+                        log.debug("Skipping TimeSeries due to missing attribute: " + a);
+                        hasAllAttributes = false;
+                        break;
+                    }
+                }
+                attrMap.put(a, val);
+            }
+
+            if (!hasAllAttributes) {
+                ++skippedTimeSeries;
+                continue;
+            }
+            String attrKey = attrMap.toString();
+
+            for (Point p : ts.getPoints()) {
+                String timestamp = p.getInterval().getEndTime();
+
+                byTime.putIfAbsent(timestamp, new HashMap<>());
+                Record rec = byTime.get(timestamp).putIfAbsent(attrKey, new Record());
+                if (rec == null) {
+                    rec = byTime.get(timestamp).get(attrKey);
+                    rec.attributes = attrMap;
+                    rec.values = new HashMap<>();
+                }
+
+                double val;
+                switch (ts.getValueType()) {
+                    case "DOUBLE":
+                        val = p.getValue().getDoubleValue();
+                        break;
+                    case "INT64":
+                        val = p.getValue().getInt64Value();
+                        break;
+                    case "BOOL":
+                        val = (p.getValue().getBoolValue()) ? 1.0 : 0.0;
+                        break;
+                    default:
+                        continue;
+                }
+
+                rec.values.put(ts.getMetric().getType(), val);
+            }
+        }
+    }
+
+    // Package scope to allow testing.
+    Datum processRecord(Record rec) throws Exception {
+        int idx = 0;
+        RealVector metricVec = new ArrayRealVector(lowMetrics.size() + highMetrics.size());
+        for (String metric : lowMetrics) {
+            metricVec.setEntry(idx, Math.pow(Math.max(rec.values.get(metric), 0.1), -1));
+            ++idx;
+        }
+        for (String metric : highMetrics) {
+            metricVec.setEntry(idx, rec.values.get(metric));
+            ++idx;
+        }
+
+        idx = 1;
+        List<Integer> attrList = new ArrayList<>(attributes.size());
+        for (String attr : attributes) {
+            attrList.add(conf.getEncoder().getIntegerEncoding(idx, rec.attributes.get(attr)));
+            ++idx;
+        }
+
+        return new Datum(attrList, metricVec);
+    }
+
+    // Package scope to allow testing.
+    MBStream<Datum> convertToStream(Map<String, Map<String, Record>> byTime) {
+        MBStream<Datum> stream = new MBStream<>();
+        for (Entry<String, Map<String, Record>> entry : byTime.entrySet()) {
+            for (Record rec : entry.getValue().values()) {
+                try {
+                    stream.add(processRecord(rec));
+                    ++pointsAdded;
+                } catch (Exception e) {
+                    // The record was incomplete.
+                    ++skippedPoints;
+                }
+            }
+        }
+
+        return stream;
+    }
+
+    /**
+     * Establishes an authenticated client using Application Default Credentials.
+     *
+     * @see "https://cloud.google.com/monitoring/demos/run_samples#before_you_begin"
+     */
+    private Monitoring buildClient() throws GeneralSecurityException, IOException {
+        // Grab the Application Default Credentials from the environment.
+        GoogleCredential credential = GoogleCredential.getApplicationDefault()
+            .createScoped(MonitoringScopes.all());
+
+        // Create and return the CloudMonitoring service object
+        HttpTransport httpTransport = new NetHttpTransport();
+        JsonFactory jsonFactory = new JacksonFactory();
+        return new Monitoring.Builder(httpTransport, jsonFactory, credential)
+            .setApplicationName("MacroBase Ingester")
+            .build();
+    }
+
+    // Package scope to allow testing.
+    static class Record {
+        public Map<String, String> attributes;
+        // {metric_type, value}
+        public Map<String, Double> values;
+    }
+
+    // A POJO that that holds configuration information about the API queries to run. The
+    // object is deserialized from JSON.
+    // Package scope to allow testing.
+    static class QueryConf {
+        static class Query {
+            private String project = "";
+            private String filter = "";
+            private String alignmentPeriod = "";
+            private String perSeriesAligner = "ALIGN_NONE";
+            private String crossSeriesReducer = "REDUCE_NONE";
+            private List<String> groupByFields = Lists.newArrayList();
+
+            public String getProject() {
+                return project;
+            }
+
+            public void setProject(String project) {
+                this.project = project;
+            }
+
+            public String getFilter() {
+                return filter;
+            }
+
+            public void setFilter(String filter) {
+                this.filter = filter;
+            }
+
+            public String getAlignmentPeriod() {
+                return alignmentPeriod;
+            }
+
+            public void setAlignmentPeriod(String alignmentPeriod) {
+                this.alignmentPeriod = alignmentPeriod;
+            }
+
+            public String getPerSeriesAligner() {
+                return perSeriesAligner;
+            }
+
+            public void setPerSeriesAligner(String perSeriesAligner) {
+                this.perSeriesAligner = perSeriesAligner;
+            }
+
+            public String getCrossSeriesReducer() {
+                return crossSeriesReducer;
+            }
+
+            public void setCrossSeriesReducer(String crossSeriesReducer) {
+                this.crossSeriesReducer = crossSeriesReducer;
+            }
+
+            public List<String> getGroupByFields() {
+                return groupByFields;
+            }
+
+            public void setGroupByFields(List<String> groupByFields) {
+                this.groupByFields = groupByFields;
+            }
+        }
+
+        private List<Query> queries = Lists.newArrayList();
+
+        public List<Query> getQueries() {
+            return queries;
+        }
+
+        public void setQueries(List<Query> queries) {
+            this.queries = queries;
+        }
+    }
+}
+

--- a/src/test/java/macrobase/conf/MacroBaseConfTest.java
+++ b/src/test/java/macrobase/conf/MacroBaseConfTest.java
@@ -6,9 +6,11 @@ import com.google.common.collect.Lists;
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.validation.BaseValidator;
+import macrobase.conf.MacroBaseConf.DataIngesterType;
 import macrobase.ingest.CSVIngester;
 import macrobase.ingest.CachingSQLIngesterTest;
 import macrobase.ingest.DiskCachingIngester;
+import macrobase.ingest.GoogleMonitoringIngester;
 import macrobase.ingest.MySQLIngester;
 import macrobase.ingest.PostgresIngester;
 import org.junit.*;
@@ -143,5 +145,8 @@ public class MacroBaseConfTest {
 
         conf.set(MacroBaseConf.DATA_LOADER_TYPE, MacroBaseConf.DataIngesterType.CACHING_POSTGRES_LOADER);
         assertTrue(conf.constructIngester() instanceof DiskCachingIngester);
+
+        conf.set(MacroBaseConf.DATA_LOADER_TYPE, DataIngesterType.GOOGLE_MONITORING_LOADER);
+        assertTrue(conf.constructIngester() instanceof GoogleMonitoringIngester);
     }
 }

--- a/src/test/java/macrobase/ingest/GoogleMonitoringIngesterTest.java
+++ b/src/test/java/macrobase/ingest/GoogleMonitoringIngesterTest.java
@@ -1,0 +1,330 @@
+package macrobase.ingest;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.services.monitoring.v3.model.ListTimeSeriesResponse;
+import com.google.api.services.monitoring.v3.model.Metric;
+import com.google.api.services.monitoring.v3.model.MonitoredResource;
+import com.google.api.services.monitoring.v3.model.Point;
+import com.google.api.services.monitoring.v3.model.TimeInterval;
+import com.google.api.services.monitoring.v3.model.TimeSeries;
+import com.google.api.services.monitoring.v3.model.TypedValue;
+import com.google.common.collect.Lists;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import macrobase.analysis.pipeline.stream.MBStream;
+import macrobase.conf.MacroBaseConf;
+import macrobase.datamodel.Datum;
+import macrobase.ingest.GoogleMonitoringIngester.QueryConf;
+import macrobase.ingest.GoogleMonitoringIngester.Record;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class GoogleMonitoringIngesterTest {
+    private static final Logger log = LoggerFactory.getLogger(GoogleMonitoringIngesterTest.class);
+
+    private MacroBaseConf conf;
+
+    @Before
+    public void setupConf() {
+        conf = new MacroBaseConf();
+
+        String queryJson =
+            "{`queries`: [{`project`: `some-project`," +
+            "`filter`: `metric.type=\\`custom.googleapis.com/test\\``," +
+            "`alignmentPeriod`: `300s`," +
+            "`perSeriesAligner`: `ALIGN_MEAN`," +
+            "`crossSeriesReducer`: `REDUCE_MEAN`," +
+            "`groupByFields`: [`foo`, `project`]}]}";
+        conf.set(MacroBaseConf.GOOGLE_MONITORING_QUERIES, queryJson.replace('`', '"'));
+        conf.set(MacroBaseConf.GOOGLE_MONITORING_START_TIME, "2016-08-08T00:00:00Z");
+        conf.set(MacroBaseConf.GOOGLE_MONITORING_END_TIME, "2016-08-09T00:00:00Z");
+
+        conf.set(MacroBaseConf.ATTRIBUTES, Lists.newArrayList("attr1", "attr2"));
+        conf.set(MacroBaseConf.LOW_METRICS, Lists.newArrayList());
+        conf.set(MacroBaseConf.HIGH_METRICS, Lists.newArrayList("custom.googleapis.com/test"));
+    }
+
+    @Test
+    public void testGetQueries() throws Exception {
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        QueryConf queryConf = ingester.getQueries(conf.getString(MacroBaseConf.GOOGLE_MONITORING_QUERIES));
+
+        assertEquals(1, queryConf.getQueries().size());
+
+        QueryConf.Query query = queryConf.getQueries().get(0);
+        assertEquals("some-project", query.getProject());
+        assertEquals("metric.type=\"custom.googleapis.com/test\"", query.getFilter());
+        assertEquals("300s", query.getAlignmentPeriod());
+        assertEquals("ALIGN_MEAN", query.getPerSeriesAligner());
+        assertEquals("REDUCE_MEAN", query.getCrossSeriesReducer());
+        assertArrayEquals(Lists.newArrayList("foo", "project").toArray(),
+                          query.getGroupByFields().toArray());
+    }
+
+    @Test
+    public void testGetQueriesUsesDefaults() throws Exception {
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        QueryConf queryConf = ingester.getQueries(
+            "{`queries`: [{`project`: `some-project`, `filter`: `metric.type=\\`custom.googleapis.com/test\\``}]}".replace('`', '"'));
+
+        assertEquals(1, queryConf.getQueries().size());
+
+        QueryConf.Query query = queryConf.getQueries().get(0);
+        assertEquals("some-project", query.getProject());
+        assertEquals("metric.type=\"custom.googleapis.com/test\"", query.getFilter());
+        assertEquals("", query.getAlignmentPeriod());
+        assertEquals("ALIGN_NONE", query.getPerSeriesAligner());
+        assertEquals("REDUCE_NONE", query.getCrossSeriesReducer());
+        assertEquals(0, query.getGroupByFields().size());
+    }
+
+    @Test
+    public void testProcessRecord() throws Exception {
+        Record record = new Record();
+        record.attributes = new TreeMap<>();
+        record.attributes.put("attr1", "foo");
+        record.attributes.put("attr2", "bar");
+        record.values = new HashMap<>();
+        record.values.put("custom.googleapis.com/test", 77.0);
+
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        Datum datum = ingester.processRecord(record);
+
+        assertEquals(77, datum.getMetrics().getEntry(0), 0.0);
+        assertEquals(0, datum.getAttributes().get(0), 0.0);
+        assertEquals(1, datum.getAttributes().get(1), 0.0);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testProcessRecordMissingMetric() throws Exception {
+        Record record = new Record();
+        record.attributes = new TreeMap<>();
+        record.attributes.put("attr1", "foo");
+        record.attributes.put("attr2", "bar");
+        record.values = new HashMap<>();
+
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        ingester.processRecord(record);
+    }
+
+    @Test
+    public void testProcessResponse() throws Exception {
+        Map<String, String> metricLabels1 = new HashMap<>();
+        metricLabels1.put("attr1", "foo");
+        metricLabels1.put("attr2", "bar");
+
+        Map<String, String> metricLabels2 = new HashMap<>();
+        metricLabels2.put("attr1", "foo");
+        metricLabels2.put("attr2", "baz");
+
+        // Missing one of the attributes. Will be skipped.
+        Map<String, String> metricLabels3 = new HashMap<>();
+        metricLabels3.put("attr1", "foo");
+
+        Metric metric1 = new Metric();
+        metric1.setType("custom.googleapis.com/test");
+        metric1.setLabels(metricLabels1);
+
+        Metric metric2 = new Metric();
+        metric2.setType("custom.googleapis.com/skipped");
+        metric2.setLabels(metricLabels1);
+
+        Metric metric3 = new Metric();
+        metric3.setType("custom.googleapis.com/test");
+        metric3.setLabels(metricLabels2);
+
+        Metric metric4 = new Metric();
+        metric4.setType("custom.googleapis.com/test");
+        metric4.setLabels(metricLabels3);
+
+        Map<String, String> resourceLabels1 = new HashMap<>();
+        resourceLabels1.put("project_id", "my-project");
+        resourceLabels1.put("region", "us-central-1");
+
+        // Get the second attribute from the resource labels.
+        Map<String, String> resourceLabels2 = new HashMap<>();
+        resourceLabels2.put("project_id", "my-project");
+        resourceLabels2.put("region", "us-central-1");
+        resourceLabels2.put("attr2", "bar");
+
+        MonitoredResource resource1 = new MonitoredResource();
+        resource1.setType("gce_instance");
+        resource1.setLabels(resourceLabels1);
+
+        MonitoredResource resource2 = new MonitoredResource();
+        resource2.setType("gce_instance");
+        resource2.setLabels(resourceLabels2);
+
+        TimeInterval time1 = new TimeInterval();
+        time1.setEndTime("2016-08-08T00:00:00Z");
+
+        TimeInterval time2 = new TimeInterval();
+        time2.setEndTime("2016-08-08T00:00:01Z");
+
+        TimeInterval time3 = new TimeInterval();
+        time3.setEndTime("2016-08-08T00:00:02Z");
+
+        Point p1 = new Point();
+        p1.setInterval(time1);
+        p1.setValue(new TypedValue());
+        p1.getValue().setDoubleValue(77.0);
+
+        Point p2 = new Point();
+        p2.setInterval(time2);
+        p2.setValue(new TypedValue());
+        p2.getValue().setDoubleValue(88.0);
+
+        Point p3 = new Point();
+        p3.setInterval(time1);
+        p3.setValue(new TypedValue());
+        p3.getValue().setInt64Value(99l);
+
+        Point p4 = new Point();
+        p4.setInterval(time3);
+        p4.setValue(new TypedValue());
+        p4.getValue().setBoolValue(true);
+
+        TimeSeries ts1 = new TimeSeries();
+        ts1.setMetric(metric1);
+        ts1.setResource(resource1);
+        ts1.setPoints(Lists.newArrayList(p1, p2));
+        ts1.setValueType("DOUBLE");
+        ts1.setMetricKind("GAUGE");
+
+        // This TimeSeries will be skipped because it has the wrong metric type.
+        TimeSeries ts2 = new TimeSeries();
+        ts2.setMetric(metric2);
+        ts2.setResource(resource1);
+        ts2.setPoints(Lists.newArrayList(p2));
+        ts2.setValueType("DOUBLE");
+        ts2.setMetricKind("GAUGE");
+
+        TimeSeries ts3 = new TimeSeries();
+        ts3.setMetric(metric3);
+        ts3.setResource(resource1);
+        ts3.setPoints(Lists.newArrayList(p3));
+        ts3.setValueType("INT64");
+        ts3.setMetricKind("GAUGE");
+
+        TimeSeries ts4 = new TimeSeries();
+        ts4.setMetric(metric4);
+        ts4.setResource(resource2);
+        ts4.setPoints(Lists.newArrayList(p4));
+        ts4.setValueType("BOOL");
+        ts4.setMetricKind("GAUGE");
+
+        ListTimeSeriesResponse response = new ListTimeSeriesResponse();
+        response.setTimeSeries(Lists.newArrayList(ts1, ts2, ts3, ts4));
+
+        Set<String> allMetrics = new HashSet<>();
+        allMetrics.add("custom.googleapis.com/test");
+
+        Map<String, Map<String, Record>> byTime = new TreeMap<>();
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        ingester.processResponse(response, allMetrics, byTime);
+
+        assertEquals(3, byTime.size());
+
+        Map<String, Record> recordMap1 = byTime.get("2016-08-08T00:00:00Z");
+        List<Record> records1 = Lists.newArrayList(recordMap1.values());
+        assertEquals(2, records1.size());
+        assertEquals(2, records1.get(0).attributes.size());
+        assertEquals("foo", records1.get(0).attributes.get("attr1"));
+        assertEquals("baz", records1.get(0).attributes.get("attr2"));
+        assertEquals(99, records1.get(0).values.get("custom.googleapis.com/test"), 0.0);
+        assertEquals(2, records1.get(1).attributes.size());
+        assertEquals("foo", records1.get(1).attributes.get("attr1"));
+        assertEquals("bar", records1.get(1).attributes.get("attr2"));
+        assertEquals(77, records1.get(1).values.get("custom.googleapis.com/test"), 0.0);
+
+        Map<String, Record> recordMap2 = byTime.get("2016-08-08T00:00:01Z");
+        List<Record> records2 = Lists.newArrayList(recordMap2.values());
+        assertEquals(1, records2.size());
+        assertEquals(2, records2.get(0).attributes.size());
+        assertEquals("foo", records2.get(0).attributes.get("attr1"));
+        assertEquals("bar", records2.get(0).attributes.get("attr2"));
+        assertEquals(88, records2.get(0).values.get("custom.googleapis.com/test"), 0.0);
+
+        Map<String, Record> recordMap3 = byTime.get("2016-08-08T00:00:02Z");
+        List<Record> records3 = Lists.newArrayList(recordMap3.values());
+        assertEquals(1, records3.size());
+        assertEquals(2, records3.get(0).attributes.size());
+        assertEquals("foo", records3.get(0).attributes.get("attr1"));
+        assertEquals("bar", records3.get(0).attributes.get("attr2"));
+        assertEquals(1.0, records3.get(0).values.get("custom.googleapis.com/test"), 0.0);
+    }
+
+    @Test
+    public void testConvertToStream() throws Exception {
+        Map<String, Map<String, Record>> byTime = new TreeMap<>();
+
+        Record record1 = new Record();
+        record1.attributes = new TreeMap<>();
+        record1.attributes.put("attr1", "foo");
+        record1.attributes.put("attr2", "bar");
+        record1.values = new HashMap<>();
+        record1.values.put("custom.googleapis.com/test", 77.0);
+
+        Record record2 = new Record();
+        record2.attributes = new TreeMap<>();
+        record2.attributes.put("attr1", "foo");
+        record2.attributes.put("attr2", "baz");
+        record2.values = new HashMap<>();
+        record2.values.put("custom.googleapis.com/test", 88.0);
+
+        // This record is incomplete and should be skipped.
+        Record record3 = new Record();
+        record3.attributes = new TreeMap<>();
+        record3.attributes.put("attr1", "foo");
+        record3.attributes.put("attr2", "bar");
+        record3.values = new HashMap<>();
+
+        Record record4 = new Record();
+        record4.attributes = new TreeMap<>();
+        record4.attributes.put("attr1", "foo");
+        record4.attributes.put("attr2", "bar");
+        record4.values = new HashMap<>();
+        record4.values.put("custom.googleapis.com/test", 99.0);
+
+        Map<String, Record> recordMap1 = new HashMap<>();
+        recordMap1.put("attr-map-key1", record1);
+        recordMap1.put("attr-map-key2", record2);
+
+        Map<String, Record> recordMap2 = new HashMap<>();
+        recordMap2.put("attr-map-key1", record3);
+
+        Map<String, Record> recordMap3 = new HashMap<>();
+        recordMap3.put("attr-map-key1", record4);
+
+        byTime.put("2016-08-08T00:00:00Z", recordMap1);
+        byTime.put("2016-08-08T00:00:01Z", recordMap2);
+        byTime.put("2016-08-08T00:00:02Z", recordMap3);
+
+        GoogleMonitoringIngester ingester = new GoogleMonitoringIngester(conf);
+        MBStream<Datum> stream = ingester.convertToStream(byTime);
+
+        List<Datum> data = stream.drain();
+        assertEquals(3, data.size(), 0.0);
+
+        assertEquals(77, data.get(0).getMetrics().getEntry(0), 0.0);
+        assertEquals(0, data.get(0).getAttributes().get(0), 0.0);
+        assertEquals(1, data.get(0).getAttributes().get(1), 0.0);
+
+        assertEquals(88, data.get(1).getMetrics().getEntry(0), 0.0);
+        assertEquals(0, data.get(1).getAttributes().get(0), 0.0);
+        assertEquals(2, data.get(1).getAttributes().get(1), 0.0);
+
+        assertEquals(99, data.get(2).getMetrics().getEntry(0), 0.0);
+        assertEquals(0, data.get(2).getAttributes().get(0), 0.0);
+        assertEquals(1, data.get(2).getAttributes().get(1), 0.0);
+    }
+}


### PR DESCRIPTION
Add a Google Monitoring API ingester, which provides access to monitoring data for resources running in GCP (and AWS if the user is a Stackdriver customer).

This is tested in batch mode using Application Default Credentials to authenticate.