### PR TITLE
Batch window average

### DIFF
--- a/contrib/src/main/java/macrobase/analysis/stats/MovingAverage.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/MovingAverage.java
@@ -19,9 +19,9 @@ public class MovingAverage extends TimeSeriesScore {
 
     private static class DatumWithInfo {
         private Datum datum;
-        private int weight;
+        private long weight;
 
-        public DatumWithInfo(Datum datum, int weight) {
+        public DatumWithInfo(Datum datum, long weight) {
             this.datum = datum;
             this.weight = weight;
         }
@@ -30,7 +30,7 @@ public class MovingAverage extends TimeSeriesScore {
             return datum;
         }
 
-        public int getWeight() {
+        public long getWeight() {
             return weight;
         }
     }
@@ -46,7 +46,7 @@ public class MovingAverage extends TimeSeriesScore {
             // until we have the second one to actually process it.
             window.add(new DatumWithInfo(newDatum, 0));
         } else {
-            int weight = newDatum.getTime(timeColumn) - getLatestDatum().getTime(timeColumn);
+            long weight = newDatum.getTime(timeColumn) - getLatestDatum().getTime(timeColumn);
             if (window.size() == 1) {
                 windowSum = new ArrayRealVector(newDatum.metrics()
                         .getDimension());
@@ -60,7 +60,7 @@ public class MovingAverage extends TimeSeriesScore {
         }
     }
 
-    private void addDatumWithWeight(Datum d, int weight) {
+    private void addDatumWithWeight(Datum d, long weight) {
         windowSum = windowSum.add(d.metrics().mapMultiply(weight));
         weightTotal += weight;
         window.add(new DatumWithInfo(d, weight));
@@ -73,7 +73,7 @@ public class MovingAverage extends TimeSeriesScore {
     @Override
     public void removeLastFromWindow() {
         DatumWithInfo head = window.remove();
-        int oldWeight = head.getWeight();
+        long oldWeight = head.getWeight();
         weightTotal -= oldWeight;
         windowSum = windowSum.subtract(head.getDatum().metrics()
                 .mapMultiply(oldWeight));

--- a/contrib/src/main/java/macrobase/analysis/transform/BatchSlidingWindowTransform.java
+++ b/contrib/src/main/java/macrobase/analysis/transform/BatchSlidingWindowTransform.java
@@ -13,12 +13,12 @@ import java.util.List;
 public class BatchSlidingWindowTransform extends SlidingWindowTransform {
     private BatchWindowAggregate windowAggregate;
 
-    public BatchSlidingWindowTransform(MacroBaseConf conf, int slideSize) throws ConfigurationException {
+    public BatchSlidingWindowTransform(MacroBaseConf conf, long slideSize) throws ConfigurationException {
         AggregateConf.AggregateType aggregateType = AggregateConf.getAggregateType(conf);
         this.windowAggregate = AggregateConf.constructBatchAggregate(conf, aggregateType);
         this.timeColumn = conf.getInt(MacroBaseConf.TIME_COLUMN, MacroBaseDefaults.TIME_COLUMN);
         this.slideSize = slideSize;
-        this.windowSize = conf.getInt(MacroBaseConf.WINDOW_SIZE, MacroBaseDefaults.WINDOW_SIZE);
+        this.windowSize = conf.getInt(MacroBaseConf.TIME_WINDOW, MacroBaseDefaults.TIME_WINDOW);
     }
 
     private void slideWindow() {

--- a/contrib/src/main/java/macrobase/analysis/transform/IncrementalSlidingWindowTransform.java
+++ b/contrib/src/main/java/macrobase/analysis/transform/IncrementalSlidingWindowTransform.java
@@ -15,12 +15,12 @@ public class IncrementalSlidingWindowTransform extends SlidingWindowTransform {
     private List<Datum> newSlide = new ArrayList<>();
     private IncrementalWindowAggregate windowAggregate;
 
-    public IncrementalSlidingWindowTransform(MacroBaseConf conf, int slideSize) throws ConfigurationException {
+    public IncrementalSlidingWindowTransform(MacroBaseConf conf, long slideSize) throws ConfigurationException {
         AggregateConf.AggregateType aggregateType = AggregateConf.getAggregateType(conf);
         this.windowAggregate = AggregateConf.constructIncrementalAggregate(conf, aggregateType);
         this.timeColumn = conf.getInt(MacroBaseConf.TIME_COLUMN, MacroBaseDefaults.TIME_COLUMN);
         this.slideSize = slideSize;
-        this.windowSize = conf.getInt(MacroBaseConf.WINDOW_SIZE, MacroBaseDefaults.WINDOW_SIZE);
+        this.windowSize = conf.getInt(MacroBaseConf.TIME_WINDOW, MacroBaseDefaults.TIME_WINDOW);
     }
 
     private List<Datum> slideWindow() {

--- a/contrib/src/main/java/macrobase/analysis/transform/SlidingWindowTransform.java
+++ b/contrib/src/main/java/macrobase/analysis/transform/SlidingWindowTransform.java
@@ -8,14 +8,14 @@ import java.util.List;
 
 public abstract class SlidingWindowTransform extends FeatureTransform {
     protected int windowSize;
-    protected int slideSize;
+    protected long slideSize;
     protected int timeColumn;
-    protected int windowStart = -1;
+    protected long windowStart = -1;
 
     protected MBStream<Datum> output = new MBStream<>();
     protected List<Datum> currWindow = new ArrayList<>();
 
-    protected boolean datumInRange(Datum d, int start, int size) {
+    protected boolean datumInRange(Datum d, long start, int size) {
         return d.getTime(timeColumn) - start < size;
     }
 }

--- a/contrib/src/main/java/macrobase/analysis/transform/aggregate/AggregateConf.java
+++ b/contrib/src/main/java/macrobase/analysis/transform/aggregate/AggregateConf.java
@@ -13,7 +13,8 @@ public class AggregateConf {
     public enum AggregateType {
         COUNT,
         SUM,
-        MAX
+        MAX,
+        AVG
     }
 
     public static AggregateType getAggregateType(MacroBaseConf conf) throws ConfigurationException {
@@ -30,6 +31,9 @@ public class AggregateConf {
             case MAX:
                 log.info("Using MAX aggregation.");
                 return new BatchWindowMax(conf);
+            case AVG:
+                log.info("Using AVG aggregation.");
+                return new BatchWindowAvg(conf);
             default:
                 throw new RuntimeException("Unhandled batch aggreation type!" + aggregateType);
         }

--- a/contrib/src/main/java/macrobase/analysis/transform/aggregate/BatchWindowAvg.java
+++ b/contrib/src/main/java/macrobase/analysis/transform/aggregate/BatchWindowAvg.java
@@ -1,0 +1,37 @@
+package macrobase.analysis.transform.aggregate;
+
+import macrobase.conf.ConfigurationException;
+import macrobase.conf.MacroBaseConf;
+import macrobase.conf.MacroBaseDefaults;
+import macrobase.datamodel.Datum;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.apache.commons.math3.linear.RealVector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchWindowAvg extends BatchWindowAggregate {
+    public BatchWindowAvg(){}
+
+    public BatchWindowAvg(MacroBaseConf conf) throws ConfigurationException {
+        this.timeColumn = conf.getInt(MacroBaseConf.TIME_COLUMN, MacroBaseDefaults.TIME_COLUMN);
+    }
+
+    public Datum aggregate(List<Datum> data) {
+        if (data.isEmpty())
+            return new Datum(new ArrayList<>(), new ArrayRealVector(dim));
+
+        dim = data.get(0).metrics().getDimension();
+        double[] results = new double[dim];
+        for (Datum d : data) {
+            RealVector metrics = d.metrics();
+            for (int i = 0; i < dim; i ++) {
+                if (timeColumn != null && i == timeColumn)
+                    continue;
+                results[i] += metrics.getEntry(i) / data.size();
+            }
+        }
+
+        return new Datum(new ArrayList<>(), new ArrayRealVector(results));
+    }
+}

--- a/contrib/src/test/java/macrobase/analysis/transform/BatchSlidingWindowTransformTest.java
+++ b/contrib/src/test/java/macrobase/analysis/transform/BatchSlidingWindowTransformTest.java
@@ -29,7 +29,7 @@ public class BatchSlidingWindowTransformTest {
 
     @Test
     public void testBasicMaxAggregate() throws Exception {
-        conf.set(MacroBaseConf.WINDOW_SIZE, 10);
+        conf.set(MacroBaseConf.TIME_WINDOW, 10);
         SlidingWindowTransform sw = new BatchSlidingWindowTransform(conf, 5);
         sw.initialize();
         sw.consume(data.subList(0, 20));
@@ -80,12 +80,12 @@ public class BatchSlidingWindowTransformTest {
     @Test
     public void testStreaming() throws Exception {
         // window = 35, slide = 25, MAX
-        conf.set(MacroBaseConf.WINDOW_SIZE, 35);
+        conf.set(MacroBaseConf.TIME_WINDOW, 35);
         // Test two different breakdowns of streams should get the same result
         testContinuousStreams(40, 85);
         testContinuousStreams(13, 57);
         // Test data streams that have gaps in between
-        conf.set(MacroBaseConf.WINDOW_SIZE, 30);
+        conf.set(MacroBaseConf.TIME_WINDOW, 30);
         testDiscontinuousStreams();
     }
 

--- a/contrib/src/test/java/macrobase/analysis/transform/IncrementalSlidingWindowTransformTest.java
+++ b/contrib/src/test/java/macrobase/analysis/transform/IncrementalSlidingWindowTransformTest.java
@@ -28,7 +28,7 @@ public class IncrementalSlidingWindowTransformTest {
 
     @Test
     public void testBasicCountAggregate() throws Exception {
-        conf.set(MacroBaseConf.WINDOW_SIZE, 10);
+        conf.set(MacroBaseConf.TIME_WINDOW, 10);
         SlidingWindowTransform sw = new IncrementalSlidingWindowTransform(conf, 5);
         sw.initialize();
         sw.consume(data.subList(0, 20));
@@ -44,7 +44,7 @@ public class IncrementalSlidingWindowTransformTest {
 
     @Test
     public void testBasicSumAggregate() throws Exception {
-        conf.set(MacroBaseConf.WINDOW_SIZE, 10);
+        conf.set(MacroBaseConf.TIME_WINDOW, 10);
         conf.set(AggregateConf.AGGREGATE_TYPE, AggregateConf.AggregateType.SUM);
         SlidingWindowTransform sw = new IncrementalSlidingWindowTransform(conf, 5);
         sw.initialize();
@@ -99,12 +99,12 @@ public class IncrementalSlidingWindowTransformTest {
     @Test
     public void testStreaming() throws Exception {
         // window = 35, slide = 25, COUNT
-        conf.set(MacroBaseConf.WINDOW_SIZE, 35);
+        conf.set(MacroBaseConf.TIME_WINDOW, 35);
         // Test two different breakdowns of streams should get the same result
         testContinuousStreams(40, 85);
         testContinuousStreams(13, 57);
         // Test data streams that have gaps in between
-        conf.set(MacroBaseConf.WINDOW_SIZE, 30);
+        conf.set(MacroBaseConf.TIME_WINDOW, 30);
         testDiscontinuousStreams();
     }
 

--- a/contrib/src/test/java/macrobase/analysis/transform/aggregate/BatchWindowAvgTest.java
+++ b/contrib/src/test/java/macrobase/analysis/transform/aggregate/BatchWindowAvgTest.java
@@ -1,0 +1,36 @@
+package macrobase.analysis.transform.aggregate;
+
+import macrobase.conf.MacroBaseConf;
+import macrobase.datamodel.Datum;
+import org.apache.commons.math3.linear.ArrayRealVector;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class BatchWindowAvgTest {
+    @Test
+    public void testAggregate() throws Exception {
+        List<Datum> data = new ArrayList<>();
+        for (int i = 0; i < 10; i ++) {
+            Datum d = new Datum(new ArrayList<>(), new ArrayRealVector(2));
+            d.metrics().setEntry(0, i);
+            d.metrics().setEntry(1, 1);
+            data.add(d);
+        }
+
+        BatchWindowAvg windowAvg = new BatchWindowAvg();
+        Datum avg = windowAvg.aggregate(data);
+        assertEquals(avg.metrics().getEntry(0), 4.5, 1e-5);
+        assertEquals(avg.metrics().getEntry(1), 1, 1e-5);
+
+        /* Test datum with time column */
+        MacroBaseConf conf = new MacroBaseConf().set(MacroBaseConf.TIME_COLUMN, 0);
+        windowAvg = new BatchWindowAvg(conf);
+        avg = windowAvg.aggregate(data);
+        assert(avg.metrics().getEntry(0) == 0);
+        assertEquals(avg.metrics().getEntry(1), 1, 1e-5);
+    }
+}

--- a/core/src/main/java/macrobase/conf/MacroBaseConf.java
+++ b/core/src/main/java/macrobase/conf/MacroBaseConf.java
@@ -40,7 +40,7 @@ public class MacroBaseConf extends Configuration {
     public static final String INLIER_ITEM_SUMMARY_SIZE = "macrobase.analysis.streaming.inlierItemSummarySize";
 
     public static final String TUPLE_WINDOW = "macrobase.analysis.timeseries.tupleWindow";
-    public static final String WINDOW_SIZE = "macrobase.analysis.timeseries.windowSize";
+    public static final String TIME_WINDOW = "macrobase.analysis.timeseries.timeWindow";
 
     public static final String MCD_ALPHA = "macrobase.analysis.mcd.alpha";
     public static final String MCD_STOPPING_DELTA = "macrobase.analysis.mcd.stoppingDelta";

--- a/core/src/main/java/macrobase/conf/MacroBaseDefaults.java
+++ b/core/src/main/java/macrobase/conf/MacroBaseDefaults.java
@@ -32,7 +32,7 @@ public class MacroBaseDefaults {
     
     // timeseries defaults
     public static final Integer TUPLE_WINDOW = 100;
-    public static final Integer WINDOW_SIZE = 86400000; // in milliseconds
+    public static final Integer TIME_WINDOW = 86400000; // in milliseconds
 
     // MCD defaults
     public static final Double MCD_ALPHA = 0.5;

--- a/core/src/main/java/macrobase/datamodel/Datum.java
+++ b/core/src/main/java/macrobase/datamodel/Datum.java
@@ -48,8 +48,8 @@ public class Datum {
         this.metrics = metrics;
     }
     
-    public int getTime(Integer timeColumn) {
-        return (int) metrics.getEntry(timeColumn);
+    public long getTime(Integer timeColumn) {
+        return (long) metrics.getEntry(timeColumn);
     }
 
     public List<Integer> attributes() {


### PR DESCRIPTION
The commit includes the following changes:
- Rename WINDOW_SIZE in MacroBaseConf to TIME_WINDOW, to make it clear that 
- Change Datum's time type from int to long, since int might be too small to express large time intervals in miliseconds
- Implemented batch window average
