### PR TITLE
Tkde foundations

### DIFF
--- a/contrib/src/main/java/macrobase/analysis/stats/kde/AlgebraUtils.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/AlgebraUtils.java
@@ -1,0 +1,71 @@
+package macrobase.analysis.stats.kde;
+
+import org.apache.commons.math3.util.FastMath;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AlgebraUtils {
+    public static double[][] getBoundingBoxRaw(List<double[]> data) {
+        int d = data.get(0).length;
+        double[][] boundaries = new double[d][2];
+        // Calculate boundaries of the data in the tree
+        for (int i = 0; i < d; i++) {
+            double maxI = -Double.MAX_VALUE;
+            double minI = Double.MAX_VALUE;
+            for (int j = 0; j < data.size(); j++) {
+                double cur = data.get(j)[i];
+                if (cur < minI) {minI = cur;}
+                if (cur > maxI) {maxI = cur;}
+            }
+            boundaries[i][0] = minI;
+            boundaries[i][1] = maxI;
+        }
+        return boundaries;
+    }
+
+    /**
+     * @param box1 box[d][0,1] are boundaries along dimension d
+     * @param box2
+     * @return two row vectors
+     */
+    public static double[][] getMinMaxDistanceBetweenBoxes(double[][] box1, double[][] box2) {
+        int k = box1.length;
+        double[][] minMaxDiff = new double[2][k];
+
+        for (int i=0; i<k; i++) {
+            double d1 = box2[i][0] - box1[i][1];
+            double d2 = box1[i][0] - box2[i][1];
+            // box2 to left
+            if (d2 >= 0) {
+                minMaxDiff[0][i] = d2;
+                minMaxDiff[1][i] = -d1;
+            }
+            // box2 to right
+            else if (d1 >= 0) {
+                minMaxDiff[0][i] = d1;
+                minMaxDiff[1][i] = -d2;
+            }
+            // inside
+            else {
+                d1 = FastMath.abs(d1);
+                d2 = FastMath.abs(d2);
+                minMaxDiff[0][i] = 0;
+                minMaxDiff[1][i] = d1 > d2 ? d1 : d2;
+            }
+        }
+
+        return minMaxDiff;
+    }
+
+    public static String array2dToString(double[][] data) {
+        StringBuilder s = new StringBuilder();
+        s.append("[");
+        for (double[] curRow : data) {
+            s.append(Arrays.toString(curRow));
+            s.append(",");
+        }
+        s.append("]");
+        return s.toString().trim();
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/AlgebraUtils.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/AlgebraUtils.java
@@ -23,49 +23,4 @@ public class AlgebraUtils {
         }
         return boundaries;
     }
-
-    /**
-     * @param box1 box[d][0,1] are boundaries along dimension d
-     * @param box2
-     * @return two row vectors
-     */
-    public static double[][] getMinMaxDistanceBetweenBoxes(double[][] box1, double[][] box2) {
-        int k = box1.length;
-        double[][] minMaxDiff = new double[2][k];
-
-        for (int i=0; i<k; i++) {
-            double d1 = box2[i][0] - box1[i][1];
-            double d2 = box1[i][0] - box2[i][1];
-            // box2 to left
-            if (d2 >= 0) {
-                minMaxDiff[0][i] = d2;
-                minMaxDiff[1][i] = -d1;
-            }
-            // box2 to right
-            else if (d1 >= 0) {
-                minMaxDiff[0][i] = d1;
-                minMaxDiff[1][i] = -d2;
-            }
-            // inside
-            else {
-                d1 = FastMath.abs(d1);
-                d2 = FastMath.abs(d2);
-                minMaxDiff[0][i] = 0;
-                minMaxDiff[1][i] = d1 > d2 ? d1 : d2;
-            }
-        }
-
-        return minMaxDiff;
-    }
-
-    public static String array2dToString(double[][] data) {
-        StringBuilder s = new StringBuilder();
-        s.append("[");
-        for (double[] curRow : data) {
-            s.append(Arrays.toString(curRow));
-            s.append(",");
-        }
-        s.append("]");
-        return s.toString().trim();
-    }
 }

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/KDTree.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/KDTree.java
@@ -1,0 +1,286 @@
+package macrobase.analysis.stats.kde;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KDTree {
+    // Parameters
+    private int leafCapacity = 20;
+    private boolean splitByWidth = false;
+
+    // Core Data
+    private int k;
+    private KDTree loChild;
+    private KDTree hiChild;
+    private ArrayList<double[]> leafItems;
+    private boolean trained = false;
+
+    // Tracking element locations
+    public int[] idxs;
+    public int startIdx, endIdx;
+
+    // Calculated Statistics
+    private int splitDimension;
+    private int nBelow;
+    private double splitValue;
+    // Array of (k,2) dimensions, of (min, max) pairs in all k dimensions
+    private double[][] boundaries;
+
+    public KDTree() {
+        splitDimension = 0;
+    }
+
+    public KDTree(KDTree parent, boolean loChild) {
+        this.k = parent.k;
+        this.idxs = parent.idxs;
+        this.splitDimension = (parent.splitDimension + 1) % k;
+        this.boundaries = new double[k][2];
+        for (int i=0;i<k;i++) {
+            this.boundaries[i][0] = parent.boundaries[i][0];
+            this.boundaries[i][1] = parent.boundaries[i][1];
+        }
+        if (loChild) {
+            this.boundaries[parent.splitDimension][1] = parent.splitValue;
+        } else {
+            this.boundaries[parent.splitDimension][0] = parent.splitValue;
+        }
+
+        leafCapacity = parent.leafCapacity;
+        splitByWidth = parent.splitByWidth;
+    }
+
+    public KDTree setSplitByWidth(boolean f) {
+        this.splitByWidth = f;
+        return this;
+    }
+    public KDTree setLeafCapacity(int leafCapacity) {
+        this.leafCapacity = leafCapacity;
+        return this;
+    }
+
+    public KDTree build(List<double[]> data) {
+        int n = data.size();
+        this.k = data.get(0).length;
+        this.idxs = new int[n];
+        this.splitDimension = 0;
+        this.boundaries = AlgebraUtils.getBoundingBoxRaw(data);
+        // Make a local copy of the data since we're going to sort it
+        double[][] dataArray = new double[n][k];
+        for (int i=0;i<n;i++) {
+            dataArray[i] = data.get(i);
+            this.idxs[i] = i;
+        }
+        buildRec(dataArray, 0, dataArray.length);
+        return this;
+    }
+
+    private KDTree buildRec(double[][] data, int startIdx, int endIdx) {
+        this.nBelow = endIdx - startIdx;
+        this.startIdx = startIdx;
+        this.endIdx = endIdx;
+
+        if (endIdx - startIdx > this.leafCapacity) {
+            double min = Double.MAX_VALUE;
+            double max = -Double.MAX_VALUE;
+            double[] splitValues = new double[endIdx-startIdx];
+            for (int j=startIdx;j<endIdx;j++) {
+                double curVal = data[j][splitDimension];
+                splitValues[j-startIdx] = curVal;
+                if (curVal < min) { min = curVal; }
+                if (curVal > max) { max = curVal; }
+            }
+            boundaries[splitDimension][0] = min;
+            boundaries[splitDimension][1] = max;
+
+            Percentile p = new Percentile();
+            p.setData(splitValues);
+            if (splitByWidth) {
+                this.splitValue = 0.5 * (p.evaluate(10) + p.evaluate(90));
+            } else {
+                this.splitValue = p.evaluate(50);
+            }
+            int l = startIdx;
+            int r = endIdx - 1;
+            while (true) {
+                while ((l < endIdx) && data[l][splitDimension] < splitValue) {
+                    l++;
+                }
+                while ((r >= startIdx) && data[r][splitDimension] >= splitValue) {
+                    r--;
+                }
+                if (l < r) {
+                    double[] tmp = data[l];
+                    data[l]= data[r];
+                    data[r]= tmp;
+
+                    int tmpI = idxs[l];
+                    this.idxs[l] = idxs[r];
+                    this.idxs[r] = tmpI;
+                } else {
+                    break;
+                }
+            }
+            if (l==startIdx || l==endIdx) {
+                l = (startIdx + endIdx) / 2;
+                this.splitValue = data[l][splitDimension];
+            }
+            this.loChild = new KDTree(this, true).buildRec(data, startIdx, l);
+            this.hiChild = new KDTree(this, false).buildRec(data, l, endIdx);
+
+        } else {
+            this.leafItems = new ArrayList<>(leafCapacity);
+
+            double[] sum = new double[k];
+            for (int j=startIdx;j<endIdx;j++) {
+                double[] d = data[j];
+                leafItems.add(d);
+            }
+        }
+
+        trained = true;
+        return this;
+    }
+
+    /**
+     * Estimates min and max difference absolute vectors from point to region
+     * @return minVec, maxVec
+     */
+    public double[][] getMinMaxDistanceVectors(double[] q) {
+        double[][] minMaxDiff = new double[2][k];
+
+        for (int i=0; i<k; i++) {
+            double d1 = q[i] - boundaries[i][0];
+            double d2 = q[i] - boundaries[i][1];
+            // outside to the right
+            if (d2 >= 0) {
+                minMaxDiff[0][i] = d2;
+                minMaxDiff[1][i] = d1;
+            }
+            // inside, min distance is 0;
+            else if (d1 >= 0) {
+                minMaxDiff[1][i] = d1 > -d2 ? d1 : -d2;
+            }
+            // outside to the left
+            else {
+                minMaxDiff[0][i] = -d1;
+                minMaxDiff[1][i] = -d2;
+            }
+        }
+
+        return minMaxDiff;
+    }
+
+    /**
+     * Estimates bounds on the distance to a region
+     * @return array with min, max distances squared
+     */
+    public double[] getMinMaxDistances(double[] q) {
+        double[][] diffVectors = getMinMaxDistanceVectors(q);
+        double[] estimates = new double[2];
+        for (int i = 0; i < k; i++) {
+            double minD = diffVectors[0][i];
+            double maxD = diffVectors[1][i];
+            estimates[0] += minD * minD;
+            estimates[1] += maxD * maxD;
+        }
+        return estimates;
+    }
+
+    public boolean isInsideBoundaries(double[] q) {
+        for (int i=0; i<k; i++) {
+            if (q[i] < this.boundaries[i][0] || q[i] > this.boundaries[i][1]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public ArrayList<double[]> getItems() {
+        return this.leafItems;
+    }
+
+    public int getNBelow() {
+        return nBelow;
+    }
+
+    public double[][] getBoundaries() {
+        return this.boundaries;
+    }
+
+    public KDTree getLoChild() {
+        return this.loChild;
+    }
+
+    public KDTree getHiChild() {
+        return this.hiChild;
+    }
+
+    public KDTree[] getChildren(double[] d) {
+        KDTree[] c = new KDTree[2];
+        if (d[splitDimension] < splitValue) {
+            c[0] = this.loChild;
+            c[1] = this.hiChild;
+        } else {
+            c[0] = this.hiChild;
+            c[1] = this.loChild;
+        }
+        return c;
+    }
+
+    public boolean isLeaf() {
+        return this.loChild == null && this.hiChild == null;
+    }
+
+    public int getSplitDimension() {
+        return splitDimension;
+    }
+
+    public double getSplitValue() {
+        return splitValue;
+    }
+
+    public Map<String, Object> toMap(boolean verbose) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        if (loChild == null && hiChild == null) {
+            if (verbose) {
+                out.put("items", this.leafItems);
+            } else {
+                out.put("n", this.leafItems.size());
+            }
+        } else {
+            out.put("dim", this.splitDimension);
+            out.put("val", this.splitValue);
+            if (loChild != null) {
+                out.put("lo", loChild.toMap(verbose));
+            }
+            if (hiChild != null) {
+                out.put("hi", hiChild.toMap(verbose));
+            }
+        }
+        if (verbose) {
+            out.put("sIdx", this.startIdx);
+            out.put("eIdx", this.endIdx);
+        }
+        return out;
+    }
+
+    public String toString() {
+        if (!trained) {
+            return "Untrained Tree";
+        } else {
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            return gson.toJson(toMap(false));
+        }
+    }
+
+    public String rawString() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(toMap(true));
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/SimpleKDE.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/SimpleKDE.java
@@ -1,0 +1,73 @@
+package macrobase.analysis.stats.kde;
+
+import macrobase.analysis.stats.kde.kernel.BandwidthSelector;
+import macrobase.analysis.stats.kde.kernel.GaussianKernel;
+import macrobase.analysis.stats.kde.kernel.Kernel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class SimpleKDE {
+    private static final Logger log = LoggerFactory.getLogger(SimpleKDE.class);
+
+    private BandwidthSelector bwSelector;
+
+    private double[] bandwidth;
+    private Kernel kernel;
+    private boolean ignoreSelf = false;
+
+    private List<double[]> trainPoints;
+    private double selfPointDensity;
+
+    public SimpleKDE() {
+        bwSelector = new BandwidthSelector();
+    }
+
+    public SimpleKDE setBandwidth(double[] bw) {this.bandwidth = bw; return this;}
+    public SimpleKDE setKernel(Kernel k) {this.kernel = k; return this;}
+    public SimpleKDE setIgnoreSelf(boolean ignoreSelf) {
+        this.ignoreSelf = ignoreSelf;
+        return this;
+    }
+
+    public double[] getBandwidth() {
+        return bandwidth;
+    }
+
+    public SimpleKDE train(List<double[]> data) {
+        this.trainPoints = data;
+        // Only calculate bandwidth if it hasn't been set by user
+        if (bandwidth == null) {
+            bandwidth = bwSelector.findBandwidth(data);
+        }
+        if (kernel == null) {
+            kernel = new GaussianKernel();
+        }
+        kernel.initialize(bandwidth);
+        this.selfPointDensity = kernel.density(new double[bandwidth.length]);
+
+        return this;
+    }
+
+    private double rawDensity(double[] d) {
+        double score = 0.0;
+        for (double[] v : trainPoints) {
+            double[] testVec = d.clone();
+            for (int i = 0; i < testVec.length; i++) {
+                testVec[i] -= v[i];
+            }
+            double delta = kernel.density(testVec);
+            score += delta;
+        }
+        return score;
+    }
+
+    public double density(double[] d) {
+        if (ignoreSelf) {
+            return (rawDensity(d) - selfPointDensity) / (trainPoints.size() - 1);
+        } else {
+            return rawDensity(d) / trainPoints.size();
+        }
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/BandwidthSelector.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/BandwidthSelector.java
@@ -1,0 +1,34 @@
+package macrobase.analysis.stats.kde.kernel;
+
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+
+import java.util.List;
+
+/**
+ * Use Scott's rule to estimate a default bandwidth for multivariate data
+ */
+public class BandwidthSelector {
+    private double userMultiplier = 1.0;
+
+    public BandwidthSelector setMultiplier(double m) {this.userMultiplier = m; return this;}
+
+    public double[] findBandwidth(List<double[]> input) {
+        int dim = input.get(0).length;
+        int n = input.size();
+        double scaleFactor = Math.pow(n, -1.0/(dim+4));
+
+        Percentile pCalc = new Percentile();
+        double[] bandwidth = new double[dim];
+
+        for (int d = 0; d < dim; d++) {
+            double[] xs = new double[n];
+            for (int i = 0; i < n; i++) {
+                xs[i] = input.get(i)[d];
+            }
+            pCalc.setData(xs);
+            bandwidth[d] = (pCalc.evaluate(75) - pCalc.evaluate(25)) * scaleFactor * userMultiplier;
+        }
+
+        return bandwidth;
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/EpaKernel.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/EpaKernel.java
@@ -1,0 +1,21 @@
+package macrobase.analysis.stats.kde.kernel;
+
+public class EpaKernel extends Kernel {
+    @Override
+    public double getDimFactor(int curDim) {
+        return Math.pow(.75, dim);
+    }
+
+    @Override
+    public double density(double[] d) {
+        double prod = 1.0;
+        for (int i=0; i < d.length; i++) {
+            double del = d[i] * invBandwidth[i];
+            if (del >= 1.0 || del <= -1.0) {
+                return 0;
+            }
+            prod *= (1.0 - del * del);
+        }
+        return dimFactor * bwFactor * prod;
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/GaussianKernel.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/GaussianKernel.java
@@ -1,0 +1,23 @@
+package macrobase.analysis.stats.kde.kernel;
+
+import org.apache.commons.math3.util.FastMath;
+
+/**
+ * Standard normal Gaussian with zero mean
+ */
+public class GaussianKernel extends Kernel {
+    @Override
+    public double getDimFactor(int curDim) {
+        return Math.pow(2*Math.PI,-.5*curDim);
+    }
+
+    @Override
+    public double density(double[] d) {
+        double dist2 = 0.0;
+        for (int i=0; i < d.length; i++) {
+            double del = d[i] * invBandwidth[i];
+            dist2 += del * del;
+        }
+        return dimFactor * bwFactor * FastMath.exp(-.5 * dist2);
+    }
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/Kernel.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/Kernel.java
@@ -1,0 +1,27 @@
+package macrobase.analysis.stats.kde.kernel;
+
+public abstract class Kernel {
+    protected int dim;
+    // store the inverse of the bandwidth for speed
+    protected double[] invBandwidth;
+
+    // Cache these constant multipliers
+    protected double dimFactor;
+    protected double bwFactor;
+
+    public Kernel initialize(double[] bs) {
+        this.dim = bs.length;
+        this.invBandwidth = new double[dim];
+        this.dimFactor = getDimFactor(dim);
+
+        this.bwFactor = 1;
+        for (int i = 0; i < dim; i++) {
+            invBandwidth[i] = 1.0/bs[i];
+            bwFactor *= invBandwidth[i];
+        }
+        return this;
+    }
+
+    public abstract double getDimFactor(int curDim);
+    public abstract double density(double[] d);
+}

--- a/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/KernelFactory.java
+++ b/contrib/src/main/java/macrobase/analysis/stats/kde/kernel/KernelFactory.java
@@ -1,0 +1,22 @@
+package macrobase.analysis.stats.kde.kernel;
+
+import java.util.function.Supplier;
+
+/**
+ * Generate kernel constructors given kernel type
+ */
+public class KernelFactory {
+    public Supplier<Kernel> supplier;
+
+    public KernelFactory(String kernel) {
+        if (kernel.equals("gaussian")) {
+            supplier = GaussianKernel::new;
+        } else {
+            supplier = EpaKernel::new;
+        }
+    }
+
+    public Kernel get() {
+        return supplier.get();
+    }
+}

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/AlgebraUtilsTest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/AlgebraUtilsTest.java
@@ -1,0 +1,59 @@
+package macrobase.analysis.stats.kde;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AlgebraUtilsTest {
+    private static final Logger log = LoggerFactory.getLogger(AlgebraUtilsTest.class);
+
+    @Test
+    public void testBoundingBox() {
+        double[][] matrixContents = {
+                {1, 2, 3},
+                {4, 5, 6},
+                {7, 8, -9},
+        };
+        List<double[]> data = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            data.add(matrixContents[i]);
+        }
+        double[][] bbox = AlgebraUtils.getBoundingBoxRaw(data);
+
+        Assert.assertEquals(1.0, bbox[0][0], 1e-10);
+        Assert.assertEquals(7.0, bbox[0][1], 1e-10);
+        Assert.assertEquals(-9.0, bbox[2][0], 1e-10);
+        Assert.assertEquals(6.0, bbox[2][1], 1e-10);
+    }
+
+    @Test
+    public void testBoundingBoxDiff() {
+        double[][] box1 = {
+                {1,4},
+                {2,5},
+                {3,6}
+        };
+        double[][] box2 = {
+                {0,1},
+                {3,4},
+                {9,10}
+        };
+
+        double[][] minMaxVectors = AlgebraUtils.getMinMaxDistanceBetweenBoxes(
+                box1,box2
+        );
+        double[][] distanceVectors = {
+                {0, 0, 3},
+                {4, 2, 7}
+        };
+        for (int i = 0; i < minMaxVectors.length; i++) {
+            for (int j = 0; j < minMaxVectors[0].length; j++) {
+                Assert.assertEquals(distanceVectors[i][j], minMaxVectors[i][j], 1e-8);
+            }
+        }
+    }
+}

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/AlgebraUtilsTest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/AlgebraUtilsTest.java
@@ -1,12 +1,13 @@
 package macrobase.analysis.stats.kde;
 
-import junit.framework.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class AlgebraUtilsTest {
     private static final Logger log = LoggerFactory.getLogger(AlgebraUtilsTest.class);
@@ -24,36 +25,9 @@ public class AlgebraUtilsTest {
         }
         double[][] bbox = AlgebraUtils.getBoundingBoxRaw(data);
 
-        Assert.assertEquals(1.0, bbox[0][0], 1e-10);
-        Assert.assertEquals(7.0, bbox[0][1], 1e-10);
-        Assert.assertEquals(-9.0, bbox[2][0], 1e-10);
-        Assert.assertEquals(6.0, bbox[2][1], 1e-10);
-    }
-
-    @Test
-    public void testBoundingBoxDiff() {
-        double[][] box1 = {
-                {1,4},
-                {2,5},
-                {3,6}
-        };
-        double[][] box2 = {
-                {0,1},
-                {3,4},
-                {9,10}
-        };
-
-        double[][] minMaxVectors = AlgebraUtils.getMinMaxDistanceBetweenBoxes(
-                box1,box2
-        );
-        double[][] distanceVectors = {
-                {0, 0, 3},
-                {4, 2, 7}
-        };
-        for (int i = 0; i < minMaxVectors.length; i++) {
-            for (int j = 0; j < minMaxVectors[0].length; j++) {
-                Assert.assertEquals(distanceVectors[i][j], minMaxVectors[i][j], 1e-8);
-            }
-        }
+        assertEquals(1.0, bbox[0][0], 1e-10);
+        assertEquals(7.0, bbox[0][1], 1e-10);
+        assertEquals(-9.0, bbox[2][0], 1e-10);
+        assertEquals(6.0, bbox[2][1], 1e-10);
     }
 }

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/KDTreeTest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/KDTreeTest.java
@@ -1,0 +1,154 @@
+package macrobase.analysis.stats.kde;
+
+import macrobase.util.data.TinyDataSource;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.*;
+
+public class KDTreeTest {
+    private static final Logger log = LoggerFactory.getLogger(KDTreeTest.class);
+    public static List<double[]> verySimpleData;
+    public static KDTree verySimpleTree;
+
+    private static List<double[]> loadVerySimple() throws Exception {
+        return new TinyDataSource().get();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception{
+        verySimpleData = loadVerySimple();
+        verySimpleTree = new KDTree()
+                .setLeafCapacity(2)
+                .build(verySimpleData);
+    }
+
+    @Test
+    public void testConstruction() throws Exception {
+        KDTree node = verySimpleTree;
+        List<double[]> data = verySimpleData;
+        assertEquals(0, node.getSplitDimension());
+        assertEquals(data.size(), node.getNBelow());
+
+        // Check that points are distributed among children
+        KDTree lo = node.getLoChild();
+        KDTree hi = node.getHiChild();
+        assertEquals(1, lo.getSplitDimension());
+        assertEquals(1, lo.getSplitDimension());
+        assertEquals(data.size(), lo.getNBelow() + hi.getNBelow());
+
+        double[][] boundaries;
+        int dimensions = data.get(0).length;
+
+        // Check boundaries for a normal tree.
+        boundaries = node.getBoundaries();
+        double[][] actualBoundaries = {
+                {1, 11},
+                {1, 7},
+                {1, 9},
+        };
+        for (int i=0; i<dimensions; i++) {
+            assertArrayEquals(actualBoundaries[i], boundaries[i], 1e-7);
+        }
+
+        // Get a Tree that is just a leaf.
+        node = new KDTree().setLeafCapacity(50).build(data);
+        boundaries = node.getBoundaries();
+        for (int i=0; i<dimensions; i++) {
+            assertArrayEquals(actualBoundaries[i], boundaries[i], 1e-7);
+        }
+        assertTrue(node.isLeaf());
+    }
+
+    @Test
+    public void testEstimateDistances() throws Exception {
+        List<double[]> data = verySimpleData;
+        KDTree node = verySimpleTree;
+        double[] zeroArray = {0, 0, 0};
+        for (double[] datum : data) {
+            // Check that minimum distance is zero if the point is inside.
+            assertArrayEquals(zeroArray, node.getMinMaxDistanceVectors(datum)[0], 1e-7);
+            assertEquals(0, node.getMinMaxDistances(datum)[0], 1e-7);
+        }
+
+        double[] farAwayPoint = {-10, 5, 21};
+        double[] minArray = {11, 0, 12};
+        double[] maxArray = {21, 4, 20};
+        double[][] minMaxVectors= node.getMinMaxDistanceVectors(farAwayPoint);
+        assertArrayEquals(minArray, minMaxVectors[0], 1e-7);
+        assertArrayEquals(maxArray, minMaxVectors[1], 1e-7);
+
+        double minDist = 265;
+        double maxDist = 857;
+        assertEquals(minDist, node.getMinMaxDistances(farAwayPoint)[0], 1e-7);
+        assertEquals(maxDist, node.getMinMaxDistances(farAwayPoint)[1], 1e-7);
+    }
+
+
+    @Test
+    public void testIsInsideBoundaries() throws Exception {
+        List<double[]> data = verySimpleData;
+        KDTree node = verySimpleTree;
+        for (double[] datum : data) {
+            assertTrue(node.isInsideBoundaries(datum));
+        }
+    }
+
+    @Test
+    public void testIsOutsideBoundaries() throws Exception {
+        KDTree node = verySimpleTree;
+
+        double[] metrics = {-1, -1, -1};
+        assertFalse(node.isInsideBoundaries(metrics));
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        List<double[]> data = verySimpleData;
+        KDTree node = verySimpleTree;
+        String str = node.toString();
+        assertThat(str.length(), greaterThan(Integer.valueOf(data.size())));
+    }
+
+    @Test
+    public void testEquiWidth() throws Exception {
+        double[][] weirdSplitData = {
+                {1.0},
+                {8.0},
+                {9.0},
+                {10.0},
+                {10.0},
+                {10.0},
+                {10.0}
+        };
+        List<double[]> weirdSplit = Arrays.asList(weirdSplitData);
+
+        KDTree node = new KDTree()
+                .setLeafCapacity(2)
+                .setSplitByWidth(true)
+                .build(weirdSplit);
+
+        assertEquals(1, node.getLoChild().getNBelow());
+        assertEquals(6, node.getHiChild().getNBelow());
+
+        assertEquals(1, node.getHiChild().getLoChild().getNBelow());
+    }
+
+    @Test
+    public void testIndices() throws Exception {
+        List<double[]> data = verySimpleData;
+        KDTree node = verySimpleTree;
+        Set<Integer> idxs = new HashSet<>(data.size());
+        for (int i : verySimpleTree.idxs) {
+            idxs.add(i);
+        }
+        for (int i=0;i<data.size();i++){
+            assertTrue("indices contain "+i, idxs.contains(i));
+        }
+    }
+}

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/SimpleKDETest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/SimpleKDETest.java
@@ -1,0 +1,62 @@
+package macrobase.analysis.stats.kde;
+
+import macrobase.analysis.stats.kde.kernel.GaussianKernel;
+import macrobase.analysis.stats.kde.kernel.Kernel;
+import macrobase.util.data.TinyDataSource;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleKDETest {
+    protected List<double[]> tinyData(int n) {
+        List<double[]> data = new ArrayList<>();
+        for (int i = 0; i < n; ++i) {
+            double[] sample = new double[1];
+            sample[0] = i;
+            data.add(sample);
+        }
+        return data;
+    }
+
+
+    @Test
+    public void oneDTest() {
+        SimpleKDE kde = new SimpleKDE();
+
+        List<double[]> data = tinyData(5);
+
+        double[] bw = new double[1];
+        bw[0] = 2;
+        kde.setBandwidth(bw);
+        kde.train(data);
+        assertEquals(2.0, kde.getBandwidth()[0], 1e-10);
+        assertEquals(2.1400523, -Math.log(kde.density(data.get(0))), 1e-5);
+        assertEquals(1.9142246, -Math.log(kde.density(data.get(1))), 1e-5);
+    }
+
+    @Test
+    public void threeDTest() throws Exception {
+        List<double[]> data = new TinyDataSource().get();
+        SimpleKDE kde = new SimpleKDE()
+                .setBandwidth(new double[]{2, 2, 2});
+        kde.train(data);
+        assertEquals(6.64640837, -Math.log(kde.density(data.get(0))), 1e-7);
+        assertEquals(7.20467317, -Math.log(kde.density(data.get(3))), 1e-7);
+    }
+
+    @Test
+    public void testIgnoreSelf() throws Exception {
+        List<double[]> data = tinyData(2);
+        double[] bw = {1};
+        Kernel k = new GaussianKernel().initialize(bw);
+        SimpleKDE kde = new SimpleKDE()
+                .setBandwidth(bw)
+                .setIgnoreSelf(true)
+                .train(data);
+        assertEquals(k.density(bw), kde.density(bw), 1e-10);
+    }
+
+}

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/kernel/BandwidthSelectorTest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/kernel/BandwidthSelectorTest.java
@@ -1,0 +1,24 @@
+package macrobase.analysis.stats.kde.kernel;
+
+import macrobase.analysis.stats.kde.kernel.BandwidthSelector;
+import macrobase.util.data.TinyDataSource;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class BandwidthSelectorTest {
+    @Test
+    public void testVerySimple() throws Exception {
+        List<double[]> data = new TinyDataSource().get();
+        BandwidthSelector s = new BandwidthSelector();
+        double[] bw = s.findBandwidth(data);
+        for (int i=0; i < bw.length; i++) {
+            assertThat(bw[i], lessThan(5.0));
+            assertThat(bw[i], greaterThan(2.0));
+        }
+    }
+}

--- a/contrib/src/test/java/macrobase/analysis/stats/kde/kernel/KernelTest.java
+++ b/contrib/src/test/java/macrobase/analysis/stats/kde/kernel/KernelTest.java
@@ -1,0 +1,68 @@
+package macrobase.analysis.stats.kde.kernel;
+
+import macrobase.analysis.stats.kde.kernel.EpaKernel;
+import macrobase.analysis.stats.kde.kernel.GaussianKernel;
+import macrobase.analysis.stats.kde.kernel.Kernel;
+import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
+import org.apache.commons.math3.linear.DiagonalMatrix;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class KernelTest {
+    @Test
+    public void test1dGaussian() {
+        double[] bw = new double[1];
+        bw[0] = 1;
+
+        Kernel g = new GaussianKernel().initialize(bw);
+
+        double[] x = new double[1];
+        x[0] = 0;
+        assertEquals(1.0/Math.sqrt(2*Math.PI), g.density(x), 1e-10);
+
+        x[0] = 5;
+    }
+
+    @Test
+    public void testMultivariateGaussian() {
+        double[] mean = {0.0, 0.0, 0.0};
+        double[] bw = {1.0, 2.0, 3.0};
+        double[][] cov = new DiagonalMatrix(new double[] {1.0, 4.0, 9.0}).getData();
+        MultivariateNormalDistribution m = new MultivariateNormalDistribution(
+                mean,
+                cov
+        );
+
+        Kernel g= new GaussianKernel().initialize(bw);
+
+        double[][] testPts = {
+                {0.0,0.0,0.0},
+                {1.0,-1.0,1.0},
+                {-3.42,-34,0.003}
+        };
+        for (double[] pt: testPts) {
+            double d1 = m.density(pt);
+            double d2 = g.density(pt);
+            assertEquals(d1, d2, 1e-10*d1);
+        }
+    }
+
+    @Test
+    public void testEpa() {
+        double[] bw = {1.0, 1.0};
+        Kernel g = new EpaKernel().initialize(bw);
+
+        double[] x1 = {0.5, 0.5};
+        double expected = .75*.75*.75*.75;
+        assertEquals(expected, g.density(x1), 1e-5);
+
+        double[] x2 = {2, 0.5};
+        assertEquals(0, g.density(x2), 1e-5);
+
+        double[] x3 = {-2, 0.5};
+        assertEquals(0, g.density(x3), 1e-5);
+    }
+
+}

--- a/contrib/src/test/java/macrobase/util/data/CSVDataSource.java
+++ b/contrib/src/test/java/macrobase/util/data/CSVDataSource.java
@@ -1,0 +1,73 @@
+package macrobase.util.data;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Quickly load csvs for use in tests
+ */
+public class CSVDataSource implements DataSource {
+    public String fileName;
+    public List<Integer> columns;
+    public int limit = Integer.MAX_VALUE;
+    public boolean hasHeader = true;
+
+    public CSVDataSource(String fileName, List<Integer> columns) {
+        this.fileName = fileName;
+        this.columns = columns;
+    }
+
+    public CSVDataSource(String fileName, int numColumns) {
+        this(fileName, new ArrayList<>(numColumns));
+        for (int i = 0; i < numColumns; i++) {
+            columns.add(i);
+        }
+    }
+
+    public CSVDataSource setHasHeader(boolean flag) {
+        this.hasHeader = flag;
+        return this;
+    }
+
+    public CSVDataSource setLimit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    @Override
+    public List<double[]> get() throws Exception {
+        Reader in = new FileReader(fileName);
+        CSVFormat format = CSVFormat.RFC4180;
+        if (hasHeader) {
+            format = format.withHeader().withSkipHeaderRecord();
+        }
+        Iterable<CSVRecord> records = format.parse(in);
+
+        int n = columns.size();
+        ArrayList<double[]> results = new ArrayList<>();
+
+        int rowCount = 0;
+        for (CSVRecord row : records) {
+            double[] dRow = new double[n];
+            for (int i = 0; i < row.size(); i++) {
+                int j = columns.indexOf(i);
+                if (j != -1) {
+                    dRow[j] = Double.parseDouble(row.get(i));
+                }
+            }
+            results.add(dRow);
+            rowCount++;
+            if (rowCount >= limit) {
+                break;
+            }
+        }
+
+        in.close();
+        return results;
+    }
+}

--- a/contrib/src/test/java/macrobase/util/data/CSVDataSourceTest.java
+++ b/contrib/src/test/java/macrobase/util/data/CSVDataSourceTest.java
@@ -1,0 +1,24 @@
+package macrobase.util.data;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSVDataSourceTest {
+    @Test
+    public void testLoadFile() throws Exception {
+        DataSource in = new CSVDataSource(
+                "src/test/resources/data/simple.csv",
+                Arrays.asList(0, 1)
+        );
+        List<double[]> metrics = in.get();
+
+        assertEquals(100, metrics.size());
+        assertEquals(2, metrics.get(1).length);
+        assertEquals(37.0, metrics.get(1)[0], 1e-10);
+        assertEquals(38.0, metrics.get(1)[1], 1e-10);
+    }
+}

--- a/contrib/src/test/java/macrobase/util/data/DataSource.java
+++ b/contrib/src/test/java/macrobase/util/data/DataSource.java
@@ -1,0 +1,11 @@
+package macrobase.util.data;
+
+import java.util.List;
+
+/**
+ * Need a way to load lists of data for use in tests without
+ * going through heavy-weight macrobase infrastructure
+ */
+public interface DataSource {
+    List<double[]> get() throws Exception;
+}

--- a/contrib/src/test/java/macrobase/util/data/TinyDataSource.java
+++ b/contrib/src/test/java/macrobase/util/data/TinyDataSource.java
@@ -1,0 +1,34 @@
+package macrobase.util.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TinyDataSource implements DataSource {
+    @Override
+    public List<double[]> get() {
+        double[][] values = {
+                {2,3,3},
+                {5,4,2},
+                {9,6,7},
+                {4,7,9},
+                {8,1,5},
+                {7,2,6},
+                {9,4,1},
+                {8,4,2},
+                {9,7,8},
+                {6,3,1},
+                {3,4,5},
+                {1,6,8},
+                {11,5,3},
+                {2,1,3},
+                {8,7,6}
+        };
+
+        ArrayList<double[]> l = new ArrayList<>();
+        for (double[] row : values) {
+            l.add(row);
+        }
+
+        return l;
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware</groupId>

--- a/core/src/test/java/macrobase/conf/MacroBaseConfTest.java
+++ b/core/src/test/java/macrobase/conf/MacroBaseConfTest.java
@@ -111,6 +111,8 @@ public class MacroBaseConfTest {
         assertArrayEquals(stringList.toArray(), conf.getStringList("this.is.a.stringList").toArray());
         assertArrayEquals(stringList.toArray(), conf.getStringList("this.is.a.stringList.without.spaces").toArray());
         assertArrayEquals(stringList.toArray(), conf.getStringList("this.is.a.stringList.with.mixed.spaces").toArray());
+
+        assertEquals(conf.getMap("namespace.b").get("inner"), "3");
     }
 
     @Test

--- a/core/src/test/resources/conf/simple.yaml
+++ b/core/src/test/resources/conf/simple.yaml
@@ -5,3 +5,7 @@ this.is.a.string: Test
 this.is.a.stringList: [T1, T2, T3, T4]
 this.is.a.stringList.without.spaces: [T1,T2,T3,T4]
 this.is.a.stringList.with.mixed.spaces: [T1, T2, T3,T4]
+
+namespace.b: {
+  inner: 3
+}


### PR DESCRIPTION
This commit includes code for kernels, kdtree, and a naive kde.
It duplicates some functionality in the existing kde code but this
implementation is much faster and I believe better factored out into
components. Some conventions that I think will be useful going forward:

1) Separate functionality into self-contained mathematical modules which
are independent of macrobase and can be tested independently of
macrobase, and then combine them at the end into a mb operator. e.g.
bandwidth selectors, kernels, and even kde. Configuration can be done
via builder pattern for better composability rather than having each
component take a config object.

2) Tests can load numeric data from a csv directly via new helper
utilities rather than going through the heavy mb csv ingester.

3) Using raw double[] rather than datum or vector yields substantial
improvements in runtime.
