### PR TITLE
Remove redirect to # on 'Explore' click

### DIFF
--- a/frontend/src/main/resources/frontend/console.html
+++ b/frontend/src/main/resources/frontend/console.html
@@ -234,7 +234,7 @@
                                 </div>
                             </div>
                             <div style="padding: 15px; padding-top:0px;">
-                                <a href="#" ng-click="exploreItems(i.items)">Explore</a>
+                                <a ng-click="exploreItems(i.items)">Explore</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
One-liner:

Old setting: the link target for "explore" redirected to "#"
Old behavior: if you click "explore", then tab back to the console, you lose your place on the page

New setting: the link target for "explore" is not defined
New behavior: if you click "explore", then tab back to the console, you keep your place

Technically, omitting the `href` tag is bad HTML, but the app doesn't even work without javascript.