### PR TITLE
initial window operator api

### DIFF
--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/MovingAverage.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/MovingAverage.java
@@ -1,0 +1,59 @@
+package edu.stanford.futuredata.macrobase.analysis.summary;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import edu.stanford.futuredata.macrobase.operator.IncrementalOperator;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class MovingAverage implements IncrementalOperator<Double> {
+    private String columnName;
+    private int windowSize = 0;
+    private Deque<Double> paneSums;
+    private Deque<Integer> paneCounts;
+
+    public MovingAverage(String columnName, int windowSize) {
+        this.columnName = columnName;
+        this.windowSize = windowSize;
+        paneSums = new ArrayDeque<>(windowSize+1);
+        paneCounts = new ArrayDeque<>(windowSize+1);
+    }
+
+    @Override
+    public void process(DataFrame input) throws Exception {
+        double[] vals = input.getDoubleColumnByName(columnName);
+        double sum = 0.0;
+        for (double v : vals) {
+            sum += v;
+        }
+        paneCounts.add(vals.length);
+        paneSums.add(sum);
+        while (paneCounts.size() > windowSize) {
+            paneCounts.removeFirst();
+            paneSums.removeFirst();
+        }
+    }
+
+    @Override
+    public Double getResults() {
+        double totalSum = 0.0;
+        long totalCount = 0;
+        for (double s : paneSums) {
+            totalSum += s;
+        }
+        for (int c : paneCounts) {
+            totalCount += c;
+        }
+        return totalSum / totalCount;
+    }
+
+    @Override
+    public void setWindowSize(int numPanes) {
+        this.windowSize = numPanes;
+    }
+
+    @Override
+    public int getWindowSize() {
+        return windowSize;
+    }
+}

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
@@ -329,12 +329,19 @@ public class DataFrame {
         return r;
     }
     public List<Row> getRows() {
+        return getRows(numRows);
+    }
+    public List<Row> getRows(int numRowsToGet) {
+        if (numRowsToGet > numRows) {
+            numRowsToGet = numRows;
+        }
         List<Row> rows = new ArrayList<>();
-        for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
+        for (int rowIdx = 0; rowIdx < numRowsToGet; rowIdx++) {
             rows.add(getRow(rowIdx));
         }
         return rows;
     }
+
     public ArrayList<double[]> getDoubleRows(List<Integer> columns) {
         ArrayList<double[]> rows = new ArrayList<>(this.numRows);
         int d = columns.size();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/IncrementalOperator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/IncrementalOperator.java
@@ -1,0 +1,8 @@
+package edu.stanford.futuredata.macrobase.operator;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+
+public interface IncrementalOperator<O> extends Operator<DataFrame,  O> {
+    void setWindowSize(int numPanes);
+    int getWindowSize();
+}

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
@@ -1,0 +1,139 @@
+package edu.stanford.futuredata.macrobase.operator;
+
+import com.google.common.base.Joiner;
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import edu.stanford.futuredata.macrobase.util.ArrayUtils;
+
+import java.util.*;
+
+/**
+ * Wraps an incremental operator to work over rolling windows.
+ * Inputs are batched into panes of [start, start+paneLength).
+ * @param <O> output type of the operator
+ */
+public class WindowedOperator<O>
+        implements Operator<DataFrame, O> {
+    private String timeColumn = "time";
+    private double windowLength = 60.0;
+    private double paneLength = 10.0;
+
+    private double maxWindowTime;
+    private IncrementalOperator<O> op;
+
+    private ArrayList<DataFrame> batchBuffer;
+
+    public WindowedOperator(IncrementalOperator op) {
+        this.op = op;
+    }
+    public WindowedOperator<O> initialize() {
+        this.maxWindowTime = 0.0;
+        this.batchBuffer = new ArrayList<>();
+
+        int numPanes = (int)Math.ceil(windowLength / paneLength);
+        op.setWindowSize(numPanes);
+        return this;
+    }
+
+
+    /**
+     * Process a small batch of data. Data is buffered until a pane (or multiple)
+     * is filled, then the internal operator state is updated with these panes.
+     * Minibatches are split to fit into panes of fixed time length.
+     * @param input minibatch of data to process
+     * @throws Exception
+     */
+    @Override
+    public void process(DataFrame input) throws Exception {
+        List<DataFrame> newPanes = addToBuffer(input);
+        for (DataFrame pane: newPanes) {
+            op.process(pane);
+        }
+    }
+
+    /**
+     * Build a pane from what is already in the buffer, call when no more events will arrive before
+     * the next pane interval.
+     * @return new effective window end time
+     */
+    public double flushBuffer() throws Exception {
+        DataFrame partialPane = DataFrame.unionAll(batchBuffer);
+        maxWindowTime += paneLength;
+        op.process(partialPane);
+        batchBuffer.clear();
+        return maxWindowTime;
+    }
+
+    /**
+     * Split buffer + input into panes, keeping any leftover rows in the buffer
+     * @param input current minibatch to aprocess
+     * @return completed panes derived from the buffer and current input
+     */
+    protected List<DataFrame> addToBuffer(DataFrame input) {
+        int n = input.getNumRows();
+        if (n == 0) {
+            return Collections.emptyList();
+        }
+        double[] times = input.getDoubleColumnByName(timeColumn);
+        double maxInputTime = ArrayUtils.max(times);
+
+        DataFrame restInput = input;
+        ArrayList<DataFrame> newPanes = new ArrayList<>(1);
+
+        // Assuming in order arrival, break up incoming batch into panes
+        while (maxInputTime >= maxWindowTime + paneLength) {
+            // When we fill up a pane, split off the overflow from the current batch
+            double nextWindowEnd = maxWindowTime + paneLength;
+            DataFrame earlyInput = restInput.filter(timeColumn, (double t) -> t < nextWindowEnd);
+            restInput = restInput.filter(timeColumn, (double t) -> t >= nextWindowEnd);
+            batchBuffer.add(earlyInput);
+            DataFrame newPane = DataFrame.unionAll(batchBuffer);
+
+            // Reset the batch buffer and start collecting for the next pane
+            maxWindowTime = nextWindowEnd;
+            batchBuffer.clear();
+            newPanes.add(newPane);
+        }
+
+        // Buffer partially filled pane until it is filled
+        batchBuffer.add(restInput);
+        return newPanes;
+    }
+
+    @Override
+    public O getResults() {
+        return op.getResults();
+    }
+
+    public String getTimeColumn() {
+        return timeColumn;
+    }
+
+    public void setTimeColumn(String timeColumn) {
+        this.timeColumn = timeColumn;
+    }
+
+    public double getWindowLength() {
+        return windowLength;
+    }
+
+    public void setWindowLength(double windowLength) {
+        this.windowLength = windowLength;
+    }
+
+    public double getPaneLength() {
+        return paneLength;
+    }
+
+    public void setPaneLength(double paneLength) {
+        this.paneLength = paneLength;
+    }
+
+    public double getMaxWindowTime() {
+        return maxWindowTime;
+    }
+
+    public int getBufferSize() {
+        return batchBuffer.size();
+    }
+}
+

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/util/ArrayUtils.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/util/ArrayUtils.java
@@ -1,0 +1,24 @@
+package edu.stanford.futuredata.macrobase.util;
+
+public class ArrayUtils {
+    public static double min(double[] a) {
+        double minValue = Double.MAX_VALUE;
+        int n = a.length;
+        for (double curValue : a) {
+            if (curValue < minValue) {
+                minValue = curValue;
+            }
+        }
+        return minValue;
+    }
+    public static double max(double[] a) {
+        double maxValue = -Double.MAX_VALUE;
+        int n = a.length;
+        for (double curValue : a) {
+            if (curValue > maxValue) {
+                maxValue = curValue;
+            }
+        }
+        return maxValue;
+    }
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/StreamingSummarizationTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/StreamingSummarizationTest.java
@@ -1,0 +1,106 @@
+package edu.stanford.futuredata.macrobase;
+
+import edu.stanford.futuredata.macrobase.analysis.summary.BatchSummarizer;
+import edu.stanford.futuredata.macrobase.analysis.summary.Explanation;
+import edu.stanford.futuredata.macrobase.analysis.summary.MovingAverage;
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class StreamingSummarizationTest {
+    /**
+     * Generates a simulated labeled dataset with both a random noise floor of outliers
+     * and a "bug" which shows up partway through and affects a specific combination of
+     * attribute values. Useful for testing streaming summarization operators.
+     *
+     * @param n number of rows
+     * @param k k-way simultaneous bad attributes required for bug
+     * @param C cardinality of each attribute column
+     * @param d dimension of number of attribute columns
+     * @param p probability of a random row being an outlier
+     * @param changeStartIdx index at which the "bug" starts showing up
+     * @return Complete dataset
+     */
+    public static DataFrame generateAnomalyDataset(
+            int n, int k, int C, int d, double p,
+            int changeStartIdx
+    ) {
+        Random r = new Random(0);
+
+        double[] time = new double[n];
+        String[][] attrs = new String[d][n];
+        double[] isOutlier = new double[n];
+        for (int i = 0; i < n; i++) {
+            double curTime = i;
+            time[i] = curTime;
+
+            int[] attrValues = new int[d];
+            for (int j = 0; j < d; j++) {
+                attrValues[j] = r.nextInt(C);
+                attrs[j][i] = String.format("a%d:%d", j, attrValues[j]);
+            }
+
+            // Outliers arise from random noies
+            // and also from matching key combination after the "event" occurs
+            boolean curOutlier = r.nextFloat() < p;
+            if (i >= changeStartIdx) {
+                boolean match = true;
+                for (int j = 0; j < k; j++) {
+                    if (attrValues[j] != 1) {
+                        match = false;
+                    }
+                }
+                if (match) {
+                    curOutlier = true;
+                }
+            }
+            isOutlier[i] = curOutlier ? 1.0 : 0.0;
+        }
+
+        DataFrame df = new DataFrame();
+        df.addDoubleColumn("time", time);
+        for (int j = 0; j < d; j++) {
+            df.addStringColumn("a"+j, attrs[j]);
+        }
+        df.addDoubleColumn("outlier", isOutlier);
+        return df;
+    }
+
+    @Test
+    public void testDetectSingleChange() throws Exception {
+        int n = 10000;
+        int k = 2;
+        int C = 4;
+        int d = 5;
+        double p = 0.01;
+        int eventIdx = 2000;
+        List<String> attributes = new ArrayList<>();
+        for (int i = 0; i < d; i++) {
+            attributes.add("a"+i);
+        }
+        DataFrame df = generateAnomalyDataset(n, k, C, d, p, eventIdx);
+        BatchSummarizer bs = new BatchSummarizer();
+        bs.setAttributes(attributes);
+        bs.setOutlierColumn("outlier");
+        bs.setUseAttributeCombinations(true);
+        bs.process(df);
+        Explanation e = bs.getResults();
+//        System.out.println(e);
+
+        int slideSize = 600;
+        // TODO: replace moving average with summarization
+        MovingAverage ma = new MovingAverage("outlier", 3);
+        double startTime = 0.0;
+        while (startTime < n) {
+            double endTime = startTime + slideSize;
+            double ls = startTime;
+            DataFrame curBatch = df.filter("time", (double t) -> t >= ls && t < endTime);
+            ma.process(curBatch);
+//            System.out.println(ma.getResults());
+            startTime = endTime;
+        }
+    }
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/MovingAverageTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/MovingAverageTest.java
@@ -1,0 +1,61 @@
+package edu.stanford.futuredata.macrobase.analysis.summary;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class MovingAverageTest {
+    private DataFrame testDF;
+
+    public static DataFrame getTestDF() {
+        // Create a block of ones surrounded by a block of zeroes
+        int n = 100;
+        int blockStart = 10;
+        int blockEnd = 20;
+        double[] times = new double[n];
+        for (int i = 0; i < n; i++) {
+            times[i] = (double)i;
+        }
+        double[] vals = new double[n];
+        for (int i = blockStart; i < blockEnd; i++) {
+            vals[i] = 1.0;
+        }
+        DataFrame data = new DataFrame();
+        data.addDoubleColumn("time", times);
+        data.addDoubleColumn("val", vals);
+
+        return data;
+    }
+
+    @Before
+    public void setUp() {
+        testDF = getTestDF();
+    }
+
+    @Test
+    public void testPanes() throws Exception {
+        MovingAverage m = new MovingAverage("val", 3);
+        int paneSize = 10;
+        int n = testDF.getNumRows();
+        int numPanes = n / paneSize;
+        for (int i = 0; i < numPanes; i++) {
+            double startTime = i * paneSize;
+            double endtime = (i+1) * paneSize;
+            DataFrame curPane = testDF.filter("time", (double t) -> (t >= startTime && t < endtime));
+            m.process(curPane);
+            if (i == 0) {
+                assertEquals(0.0, m.getResults(), 0.0);
+            } else if (i == 1) {
+                assertEquals(0.5, m.getResults(), 1e-10);
+            } else if (i == 2) {
+                assertEquals(1.0/3, m.getResults(), 1e-5);
+            } else if (i > 3) {
+                assertEquals(0.0, m.getResults(), 0.0);
+            }
+        }
+    }
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/datamodel/DataFrameTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/datamodel/DataFrameTest.java
@@ -42,5 +42,10 @@ public class DataFrameTest {
 
         filtered = tinyDF.filter(1, (double d) -> d > 2.1);
         assertEquals(1, filtered.getNumRows());
+
+        DataFrame combined = DataFrame.unionAll(
+                Arrays.asList(tinyDF, tinyDF, tinyDF)
+        );
+        assertEquals(tinyDF.getNumRows()*3, combined.getNumRows());
     }
 }

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/operator/WindowedOperatorTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/operator/WindowedOperatorTest.java
@@ -5,8 +5,6 @@ import edu.stanford.futuredata.macrobase.analysis.summary.MovingAverageTest;
 import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
 import org.junit.Test;
 
-import java.util.Random;
-
 import static org.junit.Assert.*;
 
 public class WindowedOperatorTest {
@@ -16,7 +14,7 @@ public class WindowedOperatorTest {
         WindowedOperator<Double> windowedAverageOp = new WindowedOperator<>(
                 new MovingAverage("val", 0)
         );
-        windowedAverageOp.setPaneLength(10.0);
+        windowedAverageOp.setSlideLength(10.0);
         windowedAverageOp.setTimeColumn("time");
         windowedAverageOp.setWindowLength(30.0);
         windowedAverageOp.initialize();

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/operator/WindowedOperatorTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/operator/WindowedOperatorTest.java
@@ -1,0 +1,51 @@
+package edu.stanford.futuredata.macrobase.operator;
+
+import edu.stanford.futuredata.macrobase.analysis.summary.MovingAverage;
+import edu.stanford.futuredata.macrobase.analysis.summary.MovingAverageTest;
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class WindowedOperatorTest {
+    @Test
+    public void testMovingAverage() throws Exception {
+        DataFrame data = MovingAverageTest.getTestDF();
+        WindowedOperator<Double> windowedAverageOp = new WindowedOperator<>(
+                new MovingAverage("val", 0)
+        );
+        windowedAverageOp.setPaneLength(10.0);
+        windowedAverageOp.setTimeColumn("time");
+        windowedAverageOp.setWindowLength(30.0);
+        windowedAverageOp.initialize();
+
+        int[] increments = {1, 8, 7, 3, 2, 6, 4, 20, 0, 0, 22, 2, 4};
+        double startTime = 0.0;
+        for (int miniBatchLength : increments) {
+            double endTime = startTime + miniBatchLength;
+            double ls = startTime;
+            startTime = endTime;
+
+            DataFrame miniBatch = data.filter("time", (double t) -> t >= ls && t < endTime);
+            windowedAverageOp.process(miniBatch);
+            double curAverage = windowedAverageOp.getResults();
+
+            // [10,20) is the nonzero block, so the operator will first return nonzero results
+            // when it sees an element with timestamp = 20 and knows that no more elements with
+            // t < 20 will appear
+            if (endTime > 20.0 && endTime <= 30.0) {
+                assertEquals(0.5, curAverage, 1e-10);
+            } else if (endTime > 30.0 && endTime <= 40) {
+                assertEquals(1.0 / 3, curAverage, 1e-10);
+            } else if (endTime > 50.0) {
+                assertEquals(0.0, curAverage, 0.0);
+            }
+        }
+
+        assertTrue(windowedAverageOp.getBufferSize() > 0);
+        windowedAverageOp.flushBuffer();
+        assertEquals(windowedAverageOp.getBufferSize(), 0);
+    }
+}


### PR DESCRIPTION
Wrapper for dividing minibatches with timestamps into uniformly sized panes. Minibatches that are too small will be buffered, and those that are too large will be split. 

Also included is a simple moving average summarizer to show how I'm imagining incremental operators would be written.