### PR TITLE
streaming summarizer performance

### DIFF
--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/Explanation.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/Explanation.java
@@ -2,6 +2,8 @@ package edu.stanford.futuredata.macrobase.analysis.summary;
 
 import edu.stanford.futuredata.macrobase.analysis.summary.itemset.result.AttributeSet;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -19,7 +21,9 @@ public class Explanation {
                        long numInliers,
                        long numOutliers,
                        long creationTimeMs) {
-        itemsets = resultList;
+
+        itemsets = new ArrayList<>(resultList);
+        itemsets.sort((AttributeSet a, AttributeSet b) -> -a.compareTo(b));
         this.numInliers = numInliers;
         this.numOutliers = numOutliers;
         this.creationTimeMs = creationTimeMs;

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/Explanation.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/Explanation.java
@@ -21,12 +21,44 @@ public class Explanation {
                        long numInliers,
                        long numOutliers,
                        long creationTimeMs) {
-
         itemsets = new ArrayList<>(resultList);
         itemsets.sort((AttributeSet a, AttributeSet b) -> -a.compareTo(b));
         this.numInliers = numInliers;
         this.numOutliers = numOutliers;
         this.creationTimeMs = creationTimeMs;
+    }
+
+    /**
+     * Removes redundant explanations
+     * @return New explanation with redundant itemsets removed.
+     */
+    public Explanation prune() {
+        List<AttributeSet> newItemsets = new ArrayList<>();
+        int n = itemsets.size();
+        for (int i = 0; i < n; i++) {
+            AttributeSet aSet = itemsets.get(i);
+            boolean redundant = false;
+            // an explanation is redundant if it has lower risk ratio (occurs after since sorted)
+            // than an explanation that involves a subset of the same attributes
+            for (int j = 0; j < i; j++) {
+                AttributeSet comparisonSet = itemsets.get(j);
+                if (aSet.contains(comparisonSet)) {
+                    redundant = true;
+                    break;
+                }
+            }
+            if (!redundant) {
+                newItemsets.add(aSet);
+            }
+        }
+
+        Explanation newExplanation = new Explanation(
+                newItemsets,
+                numInliers,
+                numOutliers,
+                creationTimeMs
+        );
+        return newExplanation;
     }
 
     public List<AttributeSet> getItemsets() {

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
@@ -17,6 +17,10 @@ import java.util.function.DoublePredicate;
 /**
  * Given batches of rows with an outlier class column, explain the outliers using
  * string attribute columns. Results from each batch accumulates, until batches are retired.
+ *
+ * This class searches for new candidate explanations based on the latest pane. Viable candidates
+ * are promoted and tracked until their support drops below a certain threshold, at which point they
+ * are retired.
  */
 public class IncrementalSummarizer implements IncrementalOperator<Explanation> {
     // Number of panes that we keep track in the summarizer

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
@@ -41,26 +41,35 @@ public class IncrementalSummarizer implements IncrementalOperator<Explanation> {
     private HashMap<Set<Integer>, Double> outlierItemsetWindowCount = new HashMap<>();
     private Deque<Integer> inlierPaneCounts;
     private Deque<Integer> outlierPaneCounts;
+    private HashMap<Set<Integer>, Integer> trackingMap = new HashMap<>();
+
+    // Temp Intermediate Values
     private List<Integer> inlierCountCumSum;
     private List<Integer> outlierCountCumSum;
-    private HashMap<Set<Integer>, Integer> trackingMap = new HashMap<>();
 
     public IncrementalSummarizer(int numPanes) {
         setWindowSize(numPanes);
-        if (inlierItemsetPaneCounts == null) {
-            inlierPaneCounts = new ArrayDeque<>(numPanes);
-            outlierPaneCounts = new ArrayDeque<>(numPanes);
-            inlierItemsetPaneCounts = new ArrayDeque<>(numPanes);
-            outlierItemsetPaneCounts = new ArrayDeque<>(numPanes);
-        }
     }
+
+    public IncrementalSummarizer() {
+        setWindowSize(1);
+    }
+
 
     @Override
     public void setWindowSize(int numPanes) {
         this.numPanes = numPanes;
+        initializePanes();
     }
     @Override
     public int getWindowSize() { return numPanes; }
+    protected IncrementalSummarizer initializePanes() {
+        inlierPaneCounts = new ArrayDeque<>(numPanes);
+        outlierPaneCounts = new ArrayDeque<>(numPanes);
+        inlierItemsetPaneCounts = new ArrayDeque<>(numPanes);
+        outlierItemsetPaneCounts = new ArrayDeque<>(numPanes);
+        return this;
+    }
 
     public IncrementalSummarizer setMinSupport(double minSupport) {
         this.minOutlierSupport = minSupport;

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/IncrementalSummarizer.java
@@ -49,20 +49,14 @@ public class IncrementalSummarizer implements IncrementalOperator<Explanation> {
 
     public IncrementalSummarizer(int numPanes) {
         setWindowSize(numPanes);
+        initializePanes();
     }
 
     public IncrementalSummarizer() {
         setWindowSize(1);
-    }
-
-
-    @Override
-    public void setWindowSize(int numPanes) {
-        this.numPanes = numPanes;
         initializePanes();
     }
-    @Override
-    public int getWindowSize() { return numPanes; }
+
     protected IncrementalSummarizer initializePanes() {
         inlierPaneCounts = new ArrayDeque<>(numPanes);
         outlierPaneCounts = new ArrayDeque<>(numPanes);
@@ -71,9 +65,15 @@ public class IncrementalSummarizer implements IncrementalOperator<Explanation> {
         return this;
     }
 
-    public IncrementalSummarizer setMinSupport(double minSupport) {
+    @Override
+    public void setWindowSize(int numPanes) {
+        this.numPanes = numPanes;
+    }
+    @Override
+    public int getWindowSize() { return numPanes; }
+
+    public void setMinSupport(double minSupport) {
         this.minOutlierSupport = minSupport;
-        return this;
     }
     public double getMinSupport() { return minOutlierSupport; }
 

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSet.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSet.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class AttributeSet {
+public class AttributeSet implements Comparable<AttributeSet>{
     private double support;
     private long numRecords;
     private double ratioToInliers;
@@ -71,5 +71,12 @@ public class AttributeSet {
                 ", ratioToInliers=" + ratioToInliers +
                 ", items=" + items +
                 '}';
+    }
+
+    @Override
+    public int compareTo(AttributeSet o) {
+        double r1 = this.getRatioToInliers();
+        double r2 = o.getRatioToInliers();
+        return Double.compare(r1, r2);
     }
 }

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSet.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSet.java
@@ -29,6 +29,21 @@ public class AttributeSet implements Comparable<AttributeSet>{
         this.items = items;
     }
 
+    public boolean contains(AttributeSet other) {
+        Map<String, String> otherItems = other.items;
+        for (Map.Entry<String, String> oEntry : otherItems.entrySet()) {
+            String colName = oEntry.getKey();
+            String colValue = oEntry.getValue();
+            boolean match = false;
+            if (items.containsKey(colName) && items.get(colName).equals(colValue)) {
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public String prettyPrint() {
         StringJoiner joiner = new StringJoiner("\n");
         items.forEach((k, v) -> joiner.add(k+"="+v));

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
@@ -169,35 +169,35 @@ public class DataFrame {
             n += others.get(i).numRows;
         }
         combined.numRows = n;
+        int d = first.schema.getNumColumns();
 
-        int d = first.stringCols.size();
-        combined.stringCols = new ArrayList<>(d);
         for (int colIdx = 0; colIdx < d; colIdx++) {
-            String[] newCol = new String[n];
-            int i = 0;
-            for (DataFrame curOther : others) {
-                String[] otherCol = curOther.getStringColumn(colIdx);
-                for (String curString : otherCol) {
-                    newCol[i] = curString;
-                    i++;
+            Schema.ColType t = combined.schema.getColumnType(colIdx);
+            if (t == Schema.ColType.STRING) {
+                String[] newCol = new String[n];
+                int i = 0;
+                for (DataFrame curOther : others) {
+                    String[] otherCol = curOther.getStringColumn(colIdx);
+                    for (String curString : otherCol) {
+                        newCol[i] = curString;
+                        i++;
+                    }
                 }
-            }
-            combined.stringCols.add(newCol);
-        }
-
-        d = first.doubleCols.size();
-        combined.doubleCols = new ArrayList<>(d);
-        for (int colIdx = 0; colIdx < d; colIdx++) {
-            double[] newCol = new double[n];
-            int i = 0;
-            for (DataFrame curOther : others) {
-                double[] otherCol = curOther.getDoubleColumn(colIdx);
-                for (double curString : otherCol) {
-                    newCol[i] = curString;
-                    i++;
+                combined.stringCols.add(newCol);
+            } else if (t == Schema.ColType.DOUBLE) {
+                double[] newCol = new double[n];
+                int i = 0;
+                for (DataFrame curOther : others) {
+                    double[] otherCol = curOther.getDoubleColumn(colIdx);
+                    for (double curDouble : otherCol) {
+                        newCol[i] = curDouble;
+                        i++;
+                    }
                 }
+                combined.doubleCols.add(newCol);
+            } else {
+                throw new MacrobaseInternalError("Invalid Col Type");
             }
-            combined.doubleCols.add(newCol);
         }
 
         return combined;

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
@@ -165,8 +165,8 @@ public class DataFrame {
         combined.schema = first.schema.copy();
         combined.indexToTypeIndex = new ArrayList<>(first.indexToTypeIndex);
         int n = 0;
-        for (int i = 0; i < k; i++) {
-            n += others.get(i).numRows;
+        for (DataFrame other : others) {
+            n += other.numRows;
         }
         combined.numRows = n;
         int d = first.schema.getNumColumns();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/IncrementalOperator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/IncrementalOperator.java
@@ -2,6 +2,15 @@ package edu.stanford.futuredata.macrobase.operator;
 
 import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
 
+/**
+ * An operator which supports partial updates in the form of "minibatches" of data.
+ * Results will be computed over the n previous minibatches, which is determined by setWindowSize,
+ * so this operator can be used to implement streaming algorithms.
+ *
+ * Wrap this with WindowedOperator to support time-aware sliding window operators rather than work
+ * directly with a fixed number of minibatches.
+ * @param <O> Output type of operator
+ */
 public interface IncrementalOperator<O> extends Operator<DataFrame,  O> {
     void setWindowSize(int numPanes);
     int getWindowSize();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
@@ -137,7 +137,7 @@ public class WindowedOperator<O>
     public int getBufferSize() {
         return batchBuffer.size();
     }
-    public int getBufferedRows() {
+    public int getNumBufferedRows() {
         int numRows = 0;
         for (DataFrame df : batchBuffer) {
             numRows += df.getNumRows();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/WindowedOperator.java
@@ -137,5 +137,12 @@ public class WindowedOperator<O>
     public int getBufferSize() {
         return batchBuffer.size();
     }
+    public int getBufferedRows() {
+        int numRows = 0;
+        for (DataFrame df : batchBuffer) {
+            numRows += df.getNumRows();
+        }
+        return numRows;
+    }
 }
 

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/StreamingSummarizationTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/StreamingSummarizationTest.java
@@ -1,6 +1,5 @@
 package edu.stanford.futuredata.macrobase;
 
-import edu.stanford.futuredata.macrobase.analysis.summary.BatchSummarizer;
 import edu.stanford.futuredata.macrobase.analysis.summary.Explanation;
 import edu.stanford.futuredata.macrobase.analysis.summary.IncrementalSummarizer;
 import edu.stanford.futuredata.macrobase.analysis.summary.itemset.result.AttributeSet;
@@ -10,6 +9,7 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class StreamingSummarizationTest {
@@ -18,13 +18,13 @@ public class StreamingSummarizationTest {
      * and a "bug" which shows up partway through and affects a specific combination of
      * attribute values. Useful for testing streaming summarization operators.
      *
-     * @param n number of rows
-     * @param k k-way simultaneous bad attributes required for bug
-     * @param C cardinality of each attribute column
-     * @param d dimension of number of attribute columns
-     * @param p probability of a random row being an outlier
+     * @param n              number of rows
+     * @param k              k-way simultaneous bad attributes required for bug
+     * @param C              cardinality of each attribute column
+     * @param d              dimension of number of attribute columns
+     * @param p              probability of a random row being an outlier
      * @param changeStartIdx index at which the "bug" starts showing up
-     * @param changeEndIdx index at which the "bug" ends showing up
+     * @param changeEndIdx   index at which the "bug" ends showing up
      * @return Complete dataset
      */
     public static DataFrame generateAnomalyDataset(
@@ -39,7 +39,7 @@ public class StreamingSummarizationTest {
         String[][] attrPrimitiveValues = new String[d][C];
         for (int i = 0; i < C; i++) {
             for (int j = 0; j < d; j++) {
-                attrPrimitiveValues[j][i] = String.format("a%d:%d",j,i);
+                attrPrimitiveValues[j][i] = String.format("a%d:%d", j, i);
             }
         }
 
@@ -73,7 +73,7 @@ public class StreamingSummarizationTest {
         DataFrame df = new DataFrame();
         df.addDoubleColumn("time", time);
         for (int j = 0; j < d; j++) {
-            df.addStringColumn("a"+j, attrs[j]);
+            df.addStringColumn("a" + j, attrs[j]);
         }
         df.addDoubleColumn("outlier", isOutlier);
         return df;
@@ -91,214 +91,65 @@ public class StreamingSummarizationTest {
         return attributes;
     }
 
-    /**
-     * Test the baseline performance of a windowed, streaming, summarizer operator
-     */
     @Test
-    public void testStreamingWindowed() throws Exception {
-        // Increase these numbers for more rigorous, slower performance testing
-        int n = 6000;
+    public void testDetectSingleChange() throws Exception {
+        // Prepare data set
+        int n = 7000;
         int k = 2;
-        int C = 4;
+        int C = 5;
         int d = 5;
         double p = 0.01;
         int eventIdx = 2000;
         int eventEndIdx = 4000;
         int windowSize = 2000;
-        int slideSize = 300;
-
-        DataFrame df = generateAnomalyDataset(n, k, C, d, p, eventIdx, eventEndIdx);
-        List<String> attributes = getAttributes(d, false);
-
-        IncrementalSummarizer outlierSummarizer = new IncrementalSummarizer();
-        outlierSummarizer.setAttributes(attributes);
-        outlierSummarizer.setOutlierColumn("outlier");
-        outlierSummarizer.setMinSupport(.3);
-        WindowedOperator<Explanation> windowedSummarizer = new WindowedOperator<>(outlierSummarizer);
-        windowedSummarizer.setWindowLength(windowSize);
-        windowedSummarizer.setTimeColumn("time");
-        windowedSummarizer.setSlideLength(slideSize);
-        windowedSummarizer.initialize();
-
-        BatchSummarizer bsumm = new BatchSummarizer();
-        bsumm.setAttributes(attributes);
-        bsumm.setOutlierColumn("outlier");
-        bsumm.setMinSupport(.3);
-
-        int miniBatchSize = slideSize;
-        double totalStreamingTime = 0.0;
-        double totalBatchTime = 0.0;
-
-        double startTime = 0.0;
-        while (startTime < n) {
-            double endTime = startTime + miniBatchSize;
-            double ls = startTime;
-            DataFrame curBatch = df.filter(
-                    "time",
-                    (double t) -> t >= ls && t < endTime
-            );
-            long timerStart = System.currentTimeMillis();
-            windowedSummarizer.process(curBatch);
-            Explanation curExplanation = windowedSummarizer.getResults();
-            long timerElapsed = System.currentTimeMillis() - timerStart;
-            totalStreamingTime += timerElapsed;
-
-            DataFrame curWindow = df.filter(
-                    "time",
-                    (double t) -> t >= (endTime - windowSize) && t < endTime
-            );
-            timerStart = System.currentTimeMillis();
-            bsumm.process(curWindow);
-            Explanation batchExplanation = bsumm.getResults();
-            timerElapsed = System.currentTimeMillis() - timerStart;
-            totalBatchTime += timerElapsed;
-
-            startTime = endTime;
-        }
-
-        assertTrue(totalStreamingTime < totalBatchTime);
-    }
-
-    @Test
-    public void testDetectSingleChange() throws Exception {
-        // Prepare data set
-        int n = 10000;
-        int k = 2;
-        int C = 4;
-        int d = 5;
-        double p = 0.01;
-        int eventIdx = 2000;
-        int eventEndIdx = 8000;
-        int windowSize = 6000;
-        int slideSize = 500;
-
-        List<String> attributes = getAttributes(d, false);
-        List<String> buggyAttributeValues = getAttributes(k, true);
-        DataFrame df = generateAnomalyDataset(n, k, C, d, p, eventIdx, eventEndIdx);
-        BatchSummarizer batch = new BatchSummarizer().setAttributes(attributes).setOutlierColumn("outlier");
-        batch.process(df.filter("time", (double t) -> t >= eventIdx && t < eventEndIdx));
-        Explanation batchResult = batch.getResults();
-
-        /* Code to initialize incremental summarizer */
-        IncrementalSummarizer summarizer = new IncrementalSummarizer(windowSize / slideSize);
-        summarizer.setOutlierColumn("outlier").setAttributes(attributes);
-        /* End */
-
-        double startTime = 0.0;
-        while (startTime < n) {
-            double endTime = startTime + slideSize;
-            double ls = startTime;
-            DataFrame curBatch = df.filter("time", (double t) -> t >= ls && t < endTime);
-
-            /* Code to process incremental summarizer on a minibatch */
-            summarizer.process(curBatch);
-            Explanation explanation = summarizer.getResults();
-            /* End */
-
-            assert (explanation.getNumInliers() + explanation.getNumOutliers() == Math.min(windowSize, endTime));
-
-            if (startTime < eventIdx) { // No results before event time
-                assert (explanation.getItemsets().size() == 0);
-            } else {
-                // Combination:
-                //    make sure that the known anomalous attribute combination has the highest risk ratio
-                List<AttributeSet> comboAttributes = explanation.getItemsets();
-                Collections.sort(comboAttributes,
-                        (a, b)->(new Double(b.getRatioToInliers()).compareTo(new Double(a.getRatioToInliers()))));
-                assert(comboAttributes.get(0).getItems().values().containsAll(buggyAttributeValues));
-
-                // Check whether result from the incremental summarizer in the first window agrees with
-                // results from the batch summarizer for the event
-                if (endTime == eventEndIdx) {
-                    for (AttributeSet expected : batchResult.getItemsets()) {
-                        if (expected.getItems().values().containsAll(buggyAttributeValues)) {
-                            assert(expected.getNumRecords() == comboAttributes.get(0).getNumRecords());
-                            break;
-                        }
-                    }
-                }
-            }
-            startTime = endTime;
-
-        }
-    }
-
-    @Test
-    public void testDetectEndingEvent() {
-        // Prepare data set
-        int n = 12000;
-        int k = 2;
-        int C = 5;
-        int d = 5;
-        double p = 0.005;
-        int eventIdx = 2000;
-        int eventEndIdx = 4000;
-        int windowSize = 5000;
         int slideSize = 1000;
 
         List<String> attributes = getAttributes(d, false);
         List<String> buggyAttributeValues = getAttributes(k, true);
         DataFrame df = generateAnomalyDataset(n, k, C, d, p, eventIdx, eventEndIdx);
 
-        // Summarizer with combinations
-        IncrementalSummarizer summarizer = new IncrementalSummarizer(windowSize / slideSize);
-        summarizer.setOutlierColumn("outlier").setAttributes(attributes);
+        IncrementalSummarizer outlierSummarizer = new IncrementalSummarizer();
+        outlierSummarizer.setAttributes(attributes);
+        outlierSummarizer.setOutlierColumn("outlier");
+        outlierSummarizer.setMinSupport(.5);
+        WindowedOperator<Explanation> windowedSummarizer = new WindowedOperator<>(outlierSummarizer);
+        windowedSummarizer.setWindowLength(windowSize);
+        windowedSummarizer.setTimeColumn("time");
+        windowedSummarizer.setSlideLength(slideSize);
+        windowedSummarizer.initialize();
 
+        double miniBatchSize = slideSize;
         double startTime = 0.0;
         while (startTime < n) {
-            double endTime = startTime + slideSize;
+            double endTime = startTime + miniBatchSize;
             double ls = startTime;
             DataFrame curBatch = df.filter("time", (double t) -> t >= ls && t < endTime);
-            summarizer.process(curBatch);
-            Explanation explanation = summarizer.getResults(10);
 
-            if (startTime >= eventIdx && endTime < eventEndIdx + windowSize) {
-                // Make sure that the known anomalous attribute combination has the highest risk ratio
-                // before all event panes retire
-                Collections.sort(explanation.getItemsets(),
-                        (a, b)->(new Double(b.getRatioToInliers()).compareTo(new Double(a.getRatioToInliers()))));
-                assert(explanation.getItemsets().get(0).getItems().values().containsAll(buggyAttributeValues));
+            /* Code to process windowed summarizer on a minibatch */
+            windowedSummarizer.process(curBatch);
+            Explanation explanation = windowedSummarizer.getResults();
+            /* End */
+
+            if (endTime > windowSize) {
+                assertEquals(windowSize, explanation.getNumInliers() + explanation.getNumOutliers());
+            }
+
+            if (windowedSummarizer.getMaxWindowTime() > eventIdx
+                    && windowedSummarizer.getMaxWindowTime() - windowSize < eventEndIdx) {
+                //  make sure that the known anomalous attribute combination has the highest risk ratio
+                AttributeSet topRankedExplanation = explanation.getItemsets().get(0);
+                assertTrue(topRankedExplanation.getItems().values().containsAll(buggyAttributeValues));
             } else {
-                // Make sure that there is no explanation before the event, and after all event panes retire
-                assert(explanation.getItemsets().size() == 0);
+                // Otherwise make sure that the noisy explanations are all low-cardinality
+                if (explanation.getItemsets().size() > 0) {
+                    AttributeSet topRankedExplanation = explanation.getItemsets().get(0);
+                    assertTrue(
+                            topRankedExplanation.getNumRecords() < 20
+                    );
+                }
             }
             startTime = endTime;
-        }
-    }
 
-
-    @Test
-    public void testAttributeCombo() {
-        // Prepare data set
-        int n = 16000;
-        int k = 4;
-        int C = 4;
-        int d = 10;
-        double p = 0.005;
-        int eventIdx = 0;
-        int eventEndIdx = 16000;
-        int windowSize = 4000;
-        int slideSize = 4000;
-
-        List<String> attributes = getAttributes(d, false);
-        List<String> buggyAttributeValues = getAttributes(k, true);
-        DataFrame df = generateAnomalyDataset(n, k, C, d, p, eventIdx, eventEndIdx);
-
-        // Summarizer with combinations
-        IncrementalSummarizer summarizer = new IncrementalSummarizer(windowSize / slideSize);
-        summarizer.setOutlierColumn("outlier").setAttributes(attributes);
-
-        double startTime = 0.0;
-        while (startTime < n) {
-            double endTime = startTime + slideSize;
-            double ls = startTime;
-            DataFrame curBatch = df.filter("time", (double t) -> t >= ls && t < endTime);
-            summarizer.process(curBatch);
-            Explanation explanation = summarizer.getResults(10);
-            Collections.sort(explanation.getItemsets(),
-                    (a, b)->(new Double(b.getRatioToInliers()).compareTo(new Double(a.getRatioToInliers()))));
-            assert(explanation.getItemsets().get(0).getItems().values().containsAll(buggyAttributeValues));
-            startTime = endTime;
         }
     }
 }

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/ExplanationTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/ExplanationTest.java
@@ -1,0 +1,41 @@
+package edu.stanford.futuredata.macrobase.analysis.summary;
+
+import edu.stanford.futuredata.macrobase.analysis.summary.itemset.result.AttributeSet;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ExplanationTest {
+    @Test
+    public void testPrune() throws Exception {
+        Map<String, String> v1 = new HashMap<>();
+        v1.put("c1", "val1");
+        v1.put("c2", "val2");
+
+        Map<String, String> v2 = new HashMap<>();
+        v2.put("c2", "val2");
+
+        AttributeSet a1 = new AttributeSet(
+                .2, 10.0, 21.2, v1
+        );
+        // a2 makes a1 redundant
+        AttributeSet a2 = new AttributeSet(
+                .7, 30.0, 25.0, v2
+        );
+
+        Explanation e = new Explanation(
+                Arrays.asList(a1, a2),
+                100,
+                10,
+                0
+        );
+        assertEquals(2, e.getItemsets().size());
+        assertEquals(1, e.prune().getItemsets().size());
+
+    }
+
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSetTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/summary/itemset/result/AttributeSetTest.java
@@ -1,0 +1,30 @@
+package edu.stanford.futuredata.macrobase.analysis.summary.itemset.result;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class AttributeSetTest {
+    @Test
+    public void testSimple() throws Exception {
+        Map<String, String> v1 = new HashMap<>();
+        v1.put("c1", "val1");
+        v1.put("c2", "val2");
+
+        Map<String, String> v2 = new HashMap<>();
+        v2.put("c2", "val2");
+
+        AttributeSet a1 = new AttributeSet(
+                .2, 10.0, 21.2, v1
+        );
+        AttributeSet a2 = new AttributeSet(
+                .7, 30.0, 25.0, v2
+        );
+
+        assertTrue(a1.contains(a2));
+    }
+
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/datamodel/DataFrameTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/datamodel/DataFrameTest.java
@@ -48,4 +48,33 @@ public class DataFrameTest {
         );
         assertEquals(tinyDF.getNumRows()*3, combined.getNumRows());
     }
+
+    @Test
+    public void testComplexDataFrame() {
+        DataFrame df = new DataFrame();
+        int n = 100;
+        int counter = 0;
+        for (int j = 0; j < 5; j++) {
+            if (j % 2 == 0) {
+                double[] newCol = new double[n];
+                for (int i = 0; i < n; i++) {
+                    newCol[i] = counter;
+                    counter++;
+                }
+                df.addDoubleColumn("d"+j,newCol);
+            } else {
+                String[] newCol = new String[n];
+                for (int i = 0; i < n; i++) {
+                    newCol[i] = String.valueOf(counter);
+                    counter++;
+                }
+                df.addStringColumn("s"+j,newCol);
+            }
+        }
+
+        DataFrame df2 = DataFrame.unionAll(Arrays.asList(df, df));
+        assertEquals(2*n, df2.getNumRows());
+        assertEquals(df2.getRow(0), df2.getRow(n));
+        assertEquals(2.0 * n, df2.getDoubleColumn(2)[0], 1e-10);
+    }
 }

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/integration/StreamingSummarizationBenchmark.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/integration/StreamingSummarizationBenchmark.java
@@ -1,0 +1,105 @@
+package edu.stanford.futuredata.macrobase.integration;
+
+import edu.stanford.futuredata.macrobase.StreamingSummarizationTest;
+import edu.stanford.futuredata.macrobase.analysis.summary.BatchSummarizer;
+import edu.stanford.futuredata.macrobase.analysis.summary.Explanation;
+import edu.stanford.futuredata.macrobase.analysis.summary.IncrementalSummarizer;
+import edu.stanford.futuredata.macrobase.analysis.summary.itemset.result.AttributeSet;
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import edu.stanford.futuredata.macrobase.operator.WindowedOperator;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Compare the performancce of sliding window summarization with repeated batch summarization.
+ * The incremental sliding window operator should be noticeably faster.
+ */
+public class StreamingSummarizationBenchmark {
+    public static void testWindowedPerformance() throws Exception {
+        // Increase these numbers for more rigorous, slower performance testing
+        int n = 100000;
+        int k = 3;
+        int C = 4;
+        int d = 10;
+        double p = 0.005;
+        int eventIdx = 50000;
+        int eventEndIdx = 100000;
+        int windowSize = 50000;
+        int slideSize = 1000;
+
+        DataFrame df = StreamingSummarizationTest.generateAnomalyDataset(n, k, C, d, p, eventIdx, eventEndIdx);
+        List<String> attributes = StreamingSummarizationTest.getAttributes(d, false);
+        List<String> buggyAttributeValues = StreamingSummarizationTest.getAttributes(k, true);
+
+        IncrementalSummarizer outlierSummarizer = new IncrementalSummarizer();
+        outlierSummarizer.setAttributes(attributes);
+        outlierSummarizer.setOutlierColumn("outlier");
+        outlierSummarizer.setMinSupport(.3);
+        WindowedOperator<Explanation> windowedSummarizer = new WindowedOperator<>(outlierSummarizer);
+        windowedSummarizer.setWindowLength(windowSize);
+        windowedSummarizer.setTimeColumn("time");
+        windowedSummarizer.setSlideLength(slideSize);
+        windowedSummarizer.initialize();
+
+        BatchSummarizer bsumm = new BatchSummarizer();
+        bsumm.setAttributes(attributes);
+        bsumm.setOutlierColumn("outlier");
+        bsumm.setMinSupport(.3);
+
+        int miniBatchSize = slideSize;
+        double totalStreamingTime = 0.0;
+        double totalBatchTime = 0.0;
+
+        double startTime = 0.0;
+        while (startTime < n) {
+            double endTime = startTime + miniBatchSize;
+            double ls = startTime;
+            DataFrame curBatch = df.filter(
+                    "time",
+                    (double t) -> t >= ls && t < endTime
+            );
+            long timerStart = System.currentTimeMillis();
+            windowedSummarizer.process(curBatch);
+            Explanation curExplanation = windowedSummarizer.getResults();
+            long timerElapsed = System.currentTimeMillis() - timerStart;
+            totalStreamingTime += timerElapsed;
+
+            if (windowedSummarizer.getMaxWindowTime() > eventIdx
+                    && windowedSummarizer.getMaxWindowTime() - windowSize < eventEndIdx) {
+                //  make sure that the known anomalous attribute combination has the highest risk ratio
+                AttributeSet topRankedExplanation = curExplanation.getItemsets().get(0);
+                assertTrue(topRankedExplanation.getItems().values().containsAll(buggyAttributeValues));
+            } else {
+                // Otherwise make sure that the noisy explanations are all low-cardinality
+                if (curExplanation.getItemsets().size() > 0) {
+                    AttributeSet topRankedExplanation = curExplanation.getItemsets().get(0);
+                    assertTrue(
+                            topRankedExplanation.getNumRecords() < 20
+                    );
+                }
+            }
+
+
+            DataFrame curWindow = df.filter(
+                    "time",
+                    (double t) -> t >= (endTime - windowSize) && t < endTime
+            );
+            timerStart = System.currentTimeMillis();
+            bsumm.process(curWindow);
+            Explanation batchExplanation = bsumm.getResults();
+            timerElapsed = System.currentTimeMillis() - timerStart;
+            totalBatchTime += timerElapsed;
+
+            startTime = endTime;
+        }
+
+        System.out.println("Streaming Time: "+totalStreamingTime);
+        System.out.println("Batch Time: "+totalBatchTime);
+    }
+
+    public static void main(String[] args) throws Exception {
+        testWindowedPerformance();
+    }
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/integration/StreamingSummarizationBenchmark.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/integration/StreamingSummarizationBenchmark.java
@@ -62,7 +62,9 @@ public class StreamingSummarizationBenchmark {
             );
             long timerStart = System.currentTimeMillis();
             windowedSummarizer.process(curBatch);
-            Explanation curExplanation = windowedSummarizer.getResults();
+            Explanation curExplanation = windowedSummarizer
+                    .getResults()
+                    .prune();
             long timerElapsed = System.currentTimeMillis() - timerStart;
             totalStreamingTime += timerElapsed;
 


### PR DESCRIPTION
Added a unit test for comparing streaming perf with batch perf
default values tuned for fast default unit test time, increase
to evaluate more realistic workloads.

Also fixed bug with dataframe union that was leading to issues with
windowing operator implementation