### PR TITLE
Metric Bucket Transformer

### DIFF
--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformer.java
@@ -6,16 +6,31 @@ import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 
 import java.util.*;
 
+/**
+ * Transform real valued columns into categorical string columns.
+ * Transformed columns are added to a copy of the dataframe and appended with
+ * a suffix to distinguish them from the original column.
+ * Useful for using correlated metrics as explanatory values.
+ * By default transforms columns by bucketing them into low-med-high values
+ * based on percentile.
+ */
 public class MetricBucketTransformer implements Transformer {
+    // Transformed columns are added to the dataframe under a suffix.
     private String columnSuffix = "_a";
+    // Boundaries of the buckets used for classification. n boundaries -> n+1 buckets
     private double[] boundaryPercentiles = {10.0, 90.0};
-    private boolean useSimpleNames = false;
+    // The strings used to encode which bucket a value falls in can be either a simple index
+    // or an encoding of the range of the bucket.
+    private boolean simpleBucketValues = false;
 
     private List<String> metricColumns;
     private List<String> transformedColumnNames;
 
     private DataFrame transformedDF;
 
+    /**
+     * @param columns set of columns to transform
+     */
     public MetricBucketTransformer(List<String> columns) {
         this.metricColumns = columns;
         int d = columns.size();
@@ -47,7 +62,7 @@ public class MetricBucketTransformer implements Transformer {
             }
 
             String[] bucketNames = new String[k+1];
-            if (useSimpleNames) {
+            if (simpleBucketValues) {
                 for (int i = 0; i < k+1; i++) {
                     bucketNames[i] = String.format("%s:%d", colName, i);
                 }
@@ -95,12 +110,12 @@ public class MetricBucketTransformer implements Transformer {
         this.boundaryPercentiles = boundaryPercentiles;
     }
 
-    public boolean isUseSimpleNames() {
-        return useSimpleNames;
+    public boolean isSimpleBucketValues() {
+        return simpleBucketValues;
     }
 
-    public void setUseSimpleNames(boolean useSimpleNames) {
-        this.useSimpleNames = useSimpleNames;
+    public void setSimpleBucketValues(boolean simpleBucketValues) {
+        this.simpleBucketValues = simpleBucketValues;
     }
 
     public List<String> getTransformedColumnNames() {

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformer.java
@@ -1,0 +1,109 @@
+package edu.stanford.futuredata.macrobase.analysis.transform;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import edu.stanford.futuredata.macrobase.operator.Transformer;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+
+import java.util.*;
+
+public class MetricBucketTransformer implements Transformer {
+    private String columnSuffix = "_a";
+    private double[] boundaryPercentiles = {10.0, 90.0};
+    private boolean useSimpleNames = false;
+
+    private List<String> metricColumns;
+    private List<String> transformedColumnNames;
+
+    private DataFrame transformedDF;
+
+    public MetricBucketTransformer(List<String> columns) {
+        this.metricColumns = columns;
+        int d = columns.size();
+        transformedColumnNames = new ArrayList<>(d);
+        for (String colName : metricColumns) {
+            transformedColumnNames.add(colName+columnSuffix);
+        }
+    }
+    public MetricBucketTransformer(String column) {
+        this(Collections.singletonList(column));
+    }
+
+    @Override
+    public void process(DataFrame input) throws Exception {
+        transformedDF = input.copy();
+
+        int d = metricColumns.size();
+        for (int colIdx = 0; colIdx < d; colIdx++) {
+            String colName = metricColumns.get(colIdx);
+            double[] colValues = input.getDoubleColumnByName(colName);
+
+            int n = colValues.length;
+            int k = boundaryPercentiles.length;
+            double[] curBoundaries = new double[k];
+            Percentile pCalc = new Percentile();
+            pCalc.setData(colValues);
+            for (int i = 0; i < k; i++) {
+                curBoundaries[i] = pCalc.evaluate(boundaryPercentiles[i]);
+            }
+
+            String[] bucketNames = new String[k+1];
+            if (useSimpleNames) {
+                for (int i = 0; i < k+1; i++) {
+                    bucketNames[i] = String.format("%s:%d", colName, i);
+                }
+            } else {
+                bucketNames[0] = String.format("%s:[,%g]", colName, curBoundaries[0]);
+                for (int i = 1; i < k; i++) {
+                    bucketNames[i] = String.format("%s:[%g,%g]", colName, curBoundaries[i - 1], curBoundaries[i]);
+                }
+                bucketNames[k] = String.format("%s:[%g,]", colName, curBoundaries[k - 1]);
+            }
+
+            String[] transformedColValues = new String[n];
+            for (int i = 0; i < n; i++) {
+                int searchIdx = Arrays.binarySearch(curBoundaries, colValues[i]);
+                if (searchIdx < 0) {
+                    searchIdx = -searchIdx - 1;
+                }
+                transformedColValues[i] = bucketNames[searchIdx];
+            }
+            transformedDF.addStringColumn(
+                    transformedColumnNames.get(colIdx),
+                    transformedColValues
+            );
+        }
+    }
+
+    @Override
+    public DataFrame getResults() {
+        return transformedDF;
+    }
+
+    public String getColumnSuffix() {
+        return columnSuffix;
+    }
+
+    public void setColumnSuffix(String columnSuffix) {
+        this.columnSuffix = columnSuffix;
+    }
+
+    public double[] getBoundaryPercentiles() {
+        return boundaryPercentiles;
+    }
+
+    public void setBoundaryPercentiles(double[] boundaryPercentiles) {
+        this.boundaryPercentiles = boundaryPercentiles;
+    }
+
+    public boolean isUseSimpleNames() {
+        return useSimpleNames;
+    }
+
+    public void setUseSimpleNames(boolean useSimpleNames) {
+        this.useSimpleNames = useSimpleNames;
+    }
+
+    public List<String> getTransformedColumnNames() {
+        return transformedColumnNames;
+    }
+}

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 
 /**
  * Column-based dataframe object.
- * loadRows and addColumn methods mutate the dataframe and are the primary
+ * addColumn methods mutate the dataframe and are the primary
  * ways of initializing the data in the dataframe.
  */
 public class DataFrame {

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/DataFrame.java
@@ -8,15 +8,23 @@ import java.util.function.DoublePredicate;
 import java.util.function.Predicate;
 
 /**
- * Column-based dataframe object.
- * addColumn methods mutate the dataframe and are the primary
- * ways of initializing the data in the dataframe.
+ * Column-based DataFrame object.
+ * DataFrames are primarily meant for data transfer across operators while
+ * preserving column names and types. Complex processing should be done by
+ * extracting columns as arrays and operating on arrays directly.
+ *
+ * The addColumn methods are the primary means of mutating a dataframe and are
+ * especially useful during dataframe construction. DataFrames can also be
+ * initialized from a schema and a set of rows.
  */
 public class DataFrame {
     private Schema schema;
 
     private ArrayList<String[]> stringCols;
     private ArrayList<double[]> doubleCols;
+    // external indices define a global ordering on columns, but internally each
+    // column is stored with other columns of its type. Thus external indices must be
+    // converted into internal type-specific indices.
     private ArrayList<Integer> indexToTypeIndex;
 
     private int numRows;
@@ -61,7 +69,9 @@ public class DataFrame {
     }
 
     /**
-     * @return shallow copy of dataframe
+     * Shallow copy of the dataframe: the schema is recreated but the arrays backing the
+     * columns are reused.
+     * @return shallow DataFrame copy
      */
     public DataFrame copy() {
         DataFrame other = new DataFrame();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/Row.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/Row.java
@@ -55,11 +55,16 @@ public class Row {
     public String toString() {
         ArrayList<String> strs = new ArrayList<>(vals.size());
         for (Object o : vals) {
-            String s = o.toString();
-            if (o instanceof Double) {
-                if (s.length() > 7) {
-                    double v = ((Double) o).doubleValue();
-                    s = String.format("%.6g", v);
+            String s;
+            if (o == null) {
+                s = "NULL";
+            } else {
+                s = o.toString();
+                if (o instanceof Double) {
+                    if (s.length() > 7) {
+                        double v = ((Double) o).doubleValue();
+                        s = String.format("%.6g", v);
+                    }
                 }
             }
             strs.add(s);

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/Schema.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/datamodel/Schema.java
@@ -29,6 +29,15 @@ public class Schema {
         return other;
     }
 
+    public String toString() {
+        int d = columnNames.size();
+        List<String> pairs = new ArrayList<>(d);
+        for (int i = 0; i < d; i++) {
+            pairs.add(columnNames.get(i)+":"+columnTypes.get(i));
+        }
+        return pairs.toString();
+    }
+
     public int getNumColumns() {
         return columnNames.size();
     }

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/Operator.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/operator/Operator.java
@@ -1,5 +1,13 @@
 package edu.stanford.futuredata.macrobase.operator;
 
+/**
+ * Generic interface for operations. Should not modify input.
+ * Batch operators should eagerly evaluate as much as possible in the process method,
+ * returning cached results in getResults.
+ * Streaming operators may split the work differently.
+ * @param <I> Input type
+ * @param <O> Output type
+ */
 public interface Operator<I,O> {
     void process(I input) throws Exception;
     O getResults();

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/MetricAsExplanationTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/MetricAsExplanationTest.java
@@ -59,7 +59,7 @@ public class MetricAsExplanationTest {
         c.process(df);
         DataFrame cdf = c.getResults();
 
-        List<String> metricExplanationColumns = new ArrayList<String>();
+        List<String> metricExplanationColumns = new ArrayList<>();
         for (int i = 1; i < d; i++) {
             metricExplanationColumns.add("m"+i);
         }
@@ -67,8 +67,10 @@ public class MetricAsExplanationTest {
         double[] boundaries = {5.0, 95.0};
         t.setBoundaryPercentiles(boundaries);
         t.process(cdf);
+        // tcdf now contains new columns with metrics transformed into bucketed attributes
         DataFrame tcdf = t.getResults();
 
+        // Need to retrieve the new names of the transformed columns
         List<String> bucketExplanationColumns = t.getTransformedColumnNames();
 
         BatchSummarizer bs = new BatchSummarizer();

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/MetricAsExplanationTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/MetricAsExplanationTest.java
@@ -1,0 +1,89 @@
+package edu.stanford.futuredata.macrobase;
+
+import edu.stanford.futuredata.macrobase.analysis.classify.PercentileClassifier;
+import edu.stanford.futuredata.macrobase.analysis.summary.BatchSummarizer;
+import edu.stanford.futuredata.macrobase.analysis.summary.Explanation;
+import edu.stanford.futuredata.macrobase.analysis.summary.itemset.result.AttributeSet;
+import edu.stanford.futuredata.macrobase.analysis.transform.MetricBucketTransformer;
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MetricAsExplanationTest {
+    /**
+     * @param n Number of rows
+     * @param d Number of metric columns
+     * @param k Number of correlated columns
+     * @param corr Degree of correlation
+     * @return DataFrame with correlated columns
+     */
+    public static DataFrame generateCorrelatedMetricDataset(
+            int n, int d, int k, double corr
+    ) {
+        Random r = new Random(0);
+        DataFrame df = new DataFrame();
+
+        double[] baseMetric = new double[n];
+        for (int i = 0; i < n; i++) {
+            baseMetric[i] = r.nextGaussian();
+        }
+
+        for (int j = 0; j < d; j++) {
+            double[] metric = new double[n];
+            for (int i = 0; i < n; i++) {
+                if (j < k) {
+                    metric[i] = corr*baseMetric[i] + (1-corr)*r.nextGaussian();
+                } else {
+                    metric[i] = r.nextGaussian();
+                }
+            }
+            df.addDoubleColumn("m"+j,metric);
+        }
+        return df;
+    }
+
+    @Test
+    public void testFindMetricExplanation() throws Exception {
+        int d = 6;
+        DataFrame df = generateCorrelatedMetricDataset(10000, d, 3, .95);
+
+        PercentileClassifier c = new PercentileClassifier("m0");
+        c.setPercentile(2.0);
+        c.process(df);
+        DataFrame cdf = c.getResults();
+
+        List<String> metricExplanationColumns = new ArrayList<String>();
+        for (int i = 1; i < d; i++) {
+            metricExplanationColumns.add("m"+i);
+        }
+        MetricBucketTransformer t = new MetricBucketTransformer(metricExplanationColumns);
+        double[] boundaries = {5.0, 95.0};
+        t.setBoundaryPercentiles(boundaries);
+        t.process(cdf);
+        DataFrame tcdf = t.getResults();
+
+        List<String> bucketExplanationColumns = t.getTransformedColumnNames();
+
+        BatchSummarizer bs = new BatchSummarizer();
+        bs.setOutlierColumn(c.getOutputColumnName());
+        bs.setUseAttributeCombinations(true);
+        bs.setAttributes(bucketExplanationColumns);
+        bs.setMinRiskRatio(2.0);
+        bs.setMinSupport(.3);
+        bs.process(tcdf);
+        Explanation e = bs.getResults();
+
+        List<AttributeSet> results = e.getItemsets();
+        // Top result should involve both explanatory metrics
+        assertTrue(results.get(0).getItems().keySet().containsAll(Arrays.asList("m1_a", "m2_a")));
+        assertTrue(results.size() >= 4);
+        results.get(0).getItems().keySet().contains("m1_a");
+    }
+}

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformerTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformerTest.java
@@ -29,7 +29,7 @@ public class MetricBucketTransformerTest {
         Collections.addAll(distinct, newCol);
         assertEquals(3, distinct.size());
 
-        t.setUseSimpleNames(true);
+        t.setSimpleBucketValues(true);
         t.process(df);
         tdf = t.getResults();
         assertEquals(2, tdf.getSchema().getNumColumns());

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformerTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/transform/MetricBucketTransformerTest.java
@@ -1,0 +1,72 @@
+package edu.stanford.futuredata.macrobase.analysis.transform;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class MetricBucketTransformerTest {
+    @Test
+    public void testSingleMetric() throws Exception {
+        DataFrame df = new DataFrame();
+        int n = 100;
+        double[] values = new double[n];
+        for (int i = 0; i < n; i++) {
+            values[i] = i;
+        }
+        df.addDoubleColumn("values", values);
+
+        MetricBucketTransformer t = new MetricBucketTransformer("values");
+        t.process(df);
+
+        DataFrame tdf = t.getResults();
+        assertEquals(2, tdf.getSchema().getNumColumns());
+        assertEquals(n, tdf.getNumRows());
+        String[] newCol = tdf.getStringColumnByName(t.getTransformedColumnNames().get(0));
+        Set<String> distinct = new HashSet<>();
+        Collections.addAll(distinct, newCol);
+        assertEquals(3, distinct.size());
+
+        t.setUseSimpleNames(true);
+        t.process(df);
+        tdf = t.getResults();
+        assertEquals(2, tdf.getSchema().getNumColumns());
+        assertEquals(n, tdf.getNumRows());
+        newCol = tdf.getStringColumnByName(t.getTransformedColumnNames().get(0));
+        distinct = new HashSet<>();
+        Collections.addAll(distinct, newCol);
+        assertEquals(3, distinct.size());
+    }
+
+    @Test
+    public void testComplexUsage() throws Exception {
+        DataFrame df = new DataFrame();
+        int n = 100;
+        int d = 3;
+        List<String> metricColumns = new ArrayList<>(d);
+        for (int j = 0; j < d; j++) {
+            double[] values = new double[n];
+            for (int i = 0; i < n; i++) {
+                values[i] = i;
+            }
+            String curColumnName = "m"+j;
+            metricColumns.add(curColumnName);
+            df.addDoubleColumn(curColumnName, values);
+        }
+
+        MetricBucketTransformer t = new MetricBucketTransformer(metricColumns);
+        double[] boundaries = {20.0,50.0,80.0};
+        t.setBoundaryPercentiles(boundaries);
+        t.process(df);
+        DataFrame tdf = t.getResults();
+
+        assertEquals(2*d, tdf.getSchema().getNumColumns());
+        assertEquals(n, tdf.getNumRows());
+        String[] newCol = tdf.getStringColumnByName(t.getTransformedColumnNames().get(0));
+        Set<String> distinct = new HashSet<>();
+        Collections.addAll(distinct, newCol);
+        assertEquals(4, distinct.size());
+    }
+}


### PR DESCRIPTION
Transform metrics to attributes to explain metrics using correlated other metrics. Buckets floating point value by percentiles, converting them to string attributes that are tagged with either the bucket range or the bucket index.

See MetricAsExplanationTest for complete usage. Using smaller buckets allows more precise explanations with higher risk ratio.