### PR TITLE
Fixed compatibility with AvaticaResultSet which doesn't support isLast()

### DIFF
--- a/legacy/src/main/java/macrobase/ingest/SQLIngester.java
+++ b/legacy/src/main/java/macrobase/ingest/SQLIngester.java
@@ -50,7 +50,7 @@ public abstract class SQLIngester extends DataIngester {
 
     private final MBStream<Datum> output = new MBStream<>();
     private boolean connected = false;
-    
+
     private static final String LIMIT_REGEX = "(LIMIT\\s\\d+)";
 
     public SQLIngester(MacroBaseConf conf) throws ConfigurationException, SQLException {
@@ -75,7 +75,7 @@ public abstract class SQLIngester extends DataIngester {
     public void connect() throws ConfigurationException, SQLException {
         initializeResultSet();
 
-        while(!resultSet.isLast()) {
+        while(resultSet.next()) {
             output.add(getNext());
         }
     }
@@ -216,7 +216,6 @@ public abstract class SQLIngester extends DataIngester {
     }
 
     private Datum getNext() throws SQLException {
-        resultSet.next();
         List<Integer> attrList = getAttrs(resultSet, conf.getEncoder(), 1);
         RealVector metricVec = getMetrics(resultSet, attrList.size() + 1);
 


### PR DESCRIPTION
Hello,
This PR fixes compatibility with the avatica JDBC driver, which doesn't support `isLast()` [1].

Tests are passing, please let me know if anything else needs to be done to merge.

Jacques

[1] https://github.com/apache/calcite-avatica/blob/4db1fb9c66db8ccebc9e96ce678154ec69c557f0/core/src/main/java/org/apache/calcite/avatica/AvaticaResultSet.java#L444