### PR TITLE
Bound max order in APL by number of attributes

### DIFF
--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/aplinear/APLSummarizer.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/summary/aplinear/APLSummarizer.java
@@ -75,7 +75,7 @@ public abstract class APLSummarizer extends BatchSummarizer {
                 aggregateColumns,
                 aggregationOps,
                 encoder.getNextKey(),
-                maxOrder,
+                Math.min(maxOrder, attributes.size()),
                 numThreads
         );
         log.info("Number of results: {}", aplResults.size());


### PR DESCRIPTION
The max combo order in APrioriLinear currently defaults to 3. This can cause lots of unnecessary computation when the actual number of attributes is fewer than the max combo order.

The current logic in APrioriLinear that deals with this scenario is weird: for example, if there are only two attributes (A1, A2) and we try to find order 3 results, APrioriLinear will attempt to find results composed of two values from A1 and one value from A2. Not sure why the code was written that way, but in any case this PR will avoid that scenario.