### PR TITLE
Support for range query classifiers

### DIFF
--- a/core/demo/cube_num_range.json
+++ b/core/demo/cube_num_range.json
@@ -4,10 +4,10 @@
   "classifier": "predicate",
   "countColumn": "count",
 
-  "metric": "release",
-  "predicate": "str_range",
+  "metric": "mean",
+  "predicate": "num_range",
   "cutoff": {
-    "outlier": [["12-11-10","12-30-00"], ["12-01-17"]]
+    "outlier": [[0,10], [50,100]]
   },
 
   "attributes": [

--- a/core/demo/cube_range.json
+++ b/core/demo/cube_range.json
@@ -1,0 +1,20 @@
+{
+  "pipeline": "CubePipeline",
+  "inputURI": "csv://core/demo/sample_cubed.csv",
+  "classifier": "predicate",
+  "countColumn": "count",
+
+  "metric": "release",
+  "predicate": "str_range",
+  "cutoff": {
+    "outlier": [["12-11-10","12-30-00"]]
+  },
+
+  "attributes": [
+    "location",
+    "version"
+  ],
+  "minSupport": 0.2,
+  "minRatioMetric": 2.0,
+  "ratioMetric": "riskratio"
+}

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/CountMeanShiftClassifier.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/CountMeanShiftClassifier.java
@@ -22,40 +22,26 @@ public class CountMeanShiftClassifier extends Classifier {
     /**
      * @param metricColumnName Column on which to classify outliers
      * @param meanColumnName Column containing means whose shifts will be explained
-     * @param predicateStr Predicate used for classification: "==" or "!="
-     * @param sentinel String sentinel value used when evaluating the predicate to determine outlier
+     * @param predicateStr Predicate used for classification
+     * @param sentinel sentinel value used when evaluating the predicate to determine outlier
      * @throws MacroBaseException
      */
     public CountMeanShiftClassifier(
             final String metricColumnName,
             final String meanColumnName,
             final String predicateStr,
-            final String sentinel
+            final Object sentinel
     ) throws MacroBaseException {
         super(meanColumnName);
         this.metricColumnName = metricColumnName;
         this.meanColumnName = meanColumnName;
-        this.strPredicate = MBPredicate.getStrPredicate(predicateStr, sentinel);
-        this.isStrPredicate = true;
-    }
-
-    /**
-     * @param metricColumnName Column on which to classify outliers
-     * @param meanColumnName Column containing means whose shifts will be explained
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Double sentinel value used when evaluating the predicate to determine outlier
-     */
-    public CountMeanShiftClassifier(
-            final String metricColumnName,
-            final String meanColumnName,
-            final String predicateStr,
-            final double sentinel
-    ) throws MacroBaseException {
-        super(meanColumnName);
-        this.metricColumnName = metricColumnName;
-        this.meanColumnName = meanColumnName;
-        this.doublePredicate = MBPredicate.getDoublePredicate(predicateStr, sentinel);
-        this.isStrPredicate = false;
+        MBPredicate mp = new MBPredicate(predicateStr, sentinel);
+        this.isStrPredicate = mp.isStrPredicate();
+        if (isStrPredicate) {
+            this.strPredicate = mp.getStringPredicate();
+        } else {
+            this.doublePredicate = mp.getDoublePredicate();
+        }
     }
 
     /**

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/CountMeanShiftCubedClassifier.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/CountMeanShiftCubedClassifier.java
@@ -23,8 +23,8 @@ public class CountMeanShiftCubedClassifier extends CubeClassifier {
      * @param countColumnName Column containing per-row counts
      * @param metricColumnName Column on which to classify outliers
      * @param meanColumnName Column containing means whose shifts will be explained
-     * @param predicateStr Predicate used for classification: "==" or "!="
-     * @param sentinel String sentinel value used when evaluating the predicate to determine outlier
+     * @param predicateStr Predicate used for classification
+     * @param sentinel sentinel value used when evaluating the predicate to determine outlier
      * @throws MacroBaseException
      */
     public CountMeanShiftCubedClassifier(
@@ -32,34 +32,18 @@ public class CountMeanShiftCubedClassifier extends CubeClassifier {
             final String metricColumnName,
             final String meanColumnName,
             final String predicateStr,
-            final String sentinel
+            final Object sentinel
     ) throws MacroBaseException {
         super(countColumnName);
         this.metricColumnName = metricColumnName;
         this.meanColumnName = meanColumnName;
-        this.strPredicate = MBPredicate.getStrPredicate(predicateStr, sentinel);
-        this.isStrPredicate = true;
-    }
-
-    /**
-     * @param countColumnName Column containing per-row counts
-     * @param metricColumnName Column on which to classify outliers
-     * @param meanColumnName Column containing means whose shifts will be explained
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Double sentinel value used when evaluating the predicate to determine outlier
-     */
-    public CountMeanShiftCubedClassifier(
-            final String countColumnName,
-            final String metricColumnName,
-            final String meanColumnName,
-            final String predicateStr,
-            final double sentinel
-    ) throws MacroBaseException {
-        super(countColumnName);
-        this.metricColumnName = metricColumnName;
-        this.meanColumnName = meanColumnName;
-        this.doublePredicate = MBPredicate.getDoublePredicate(predicateStr, sentinel);
-        this.isStrPredicate = false;
+        MBPredicate mp = new MBPredicate(predicateStr, sentinel);
+        this.isStrPredicate = mp.isStrPredicate();
+        if (isStrPredicate) {
+            this.strPredicate = mp.getStringPredicate();
+        } else {
+            this.doublePredicate = mp.getDoublePredicate();
+        }
     }
 
     /**

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateClassifier.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateClassifier.java
@@ -29,31 +29,19 @@ public class PredicateClassifier extends Classifier {
     private boolean isStrPredicate;
 
 
-    /**
-     * @param columnName Column on which to classifier outliers
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Sentinel value used when evaluating the predicate to determine outlier
-     */
-    public PredicateClassifier(final String columnName, final String predicateStr,
-        final double sentinel)
-        throws MacroBaseException {
+    public PredicateClassifier(
+            final String columnName,
+            final String predicateStr,
+            final Object sentinel
+    ) throws MacroBaseException {
         super(columnName);
-        this.predicate = MBPredicate.getDoublePredicate(predicateStr, sentinel);
-        this.isStrPredicate = false;
-    }
-
-
-    /**
-     * @param columnName Column on which to classifier outliers
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Sentinel value used when evaluating the predicate to determine outlier
-     */
-    public PredicateClassifier(final String columnName, final String predicateStr,
-        final String sentinel)
-        throws MacroBaseException {
-        super(columnName);
-        this.strPredicate = MBPredicate.getStrPredicate(predicateStr, sentinel);
-        this.isStrPredicate = true;
+        MBPredicate mp = new MBPredicate(predicateStr, sentinel);
+        this.isStrPredicate = mp.isStrPredicate();
+        if (isStrPredicate) {
+            this.strPredicate = mp.getStringPredicate();
+        } else {
+            this.predicate = mp.getDoublePredicate();
+        }
     }
 
     /**

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifier.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifier.java
@@ -4,6 +4,9 @@ import edu.stanford.futuredata.macrobase.analysis.classify.stats.MBPredicate;
 import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
 import edu.stanford.futuredata.macrobase.util.MacroBaseException;
 
+import javax.crypto.Mac;
+import java.util.Collection;
+import java.util.Map;
 import java.util.function.DoublePredicate;
 import java.util.function.Predicate;
 
@@ -21,44 +24,22 @@ public class PredicateCubeClassifier extends CubeClassifier {
     private String metricColumnName; //hack
     private boolean isStrPredicate;
 
-
-    /**
-     * @param metricColumnName Column on which to classifier outliers
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Sentinel value used when evaluating the predicate to determine outlier
-     * @throws MacroBaseException
-     */
     public PredicateCubeClassifier(
             final String countColumnName,
             final String metricColumnName,
             final String predicateStr,
-            final double sentinel
+            final Object sentinel
     ) throws MacroBaseException {
         super(countColumnName);
         this.metricColumnName = metricColumnName;
-        this.predicate = MBPredicate.getDoublePredicate(predicateStr, sentinel);
-        this.isStrPredicate = false;
+        MBPredicate mp = new MBPredicate(predicateStr, sentinel);
+        this.isStrPredicate = mp.isStrPredicate();
+        if (isStrPredicate) {
+            this.strPredicate = mp.getStringPredicate();
+        } else {
+            this.predicate = mp.getDoublePredicate();
+        }
     }
-
-
-    /**
-     * @param metricColumnName Column on which to classifier outliers
-     * @param predicateStr Predicate used for classification: "==", "!=", "<", ">", "<=", or ">="
-     * @param sentinel Sentinel value used when evaluating the predicate to determine outlier
-     * @throws MacroBaseException
-     */
-    public PredicateCubeClassifier(
-            final String countColumnName,
-            final String metricColumnName,
-            final String predicateStr,
-            final String sentinel
-    ) throws MacroBaseException {
-        super(countColumnName);
-        this.metricColumnName = metricColumnName;
-        this.strPredicate = MBPredicate.getStrPredicate(predicateStr, sentinel);
-        this.isStrPredicate = true;
-    }
-
 
     /**
      * Scan through the metric column, and evaluate the predicate on every value in the column. The ``input'' DataFrame

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifier.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifier.java
@@ -4,9 +4,6 @@ import edu.stanford.futuredata.macrobase.analysis.classify.stats.MBPredicate;
 import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
 import edu.stanford.futuredata.macrobase.util.MacroBaseException;
 
-import javax.crypto.Mac;
-import java.util.Collection;
-import java.util.Map;
 import java.util.function.DoublePredicate;
 import java.util.function.Predicate;
 
@@ -47,7 +44,7 @@ public class PredicateCubeClassifier extends CubeClassifier {
      * @throws Exception
      */
     @Override
-    public void process(DataFrame input) throws Exception {
+    public void process(DataFrame input) {
         if (isStrPredicate) {
             processString(input);
         } else {
@@ -56,7 +53,7 @@ public class PredicateCubeClassifier extends CubeClassifier {
     }
 
 
-    public void processDouble(DataFrame input) throws Exception {
+    public void processDouble(DataFrame input) {
         double[] metrics = input.getDoubleColumnByName(metricColumnName);
         int len = metrics.length;
         output = input.copy();
@@ -74,7 +71,7 @@ public class PredicateCubeClassifier extends CubeClassifier {
     }
 
 
-    public void processString(DataFrame input) throws Exception {
+    public void processString(DataFrame input) {
         String[] metrics = input.getStringColumnByName(metricColumnName);
         int len = metrics.length;
         output = input.copy();

--- a/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/stats/MBPredicate.java
+++ b/lib/src/main/java/edu/stanford/futuredata/macrobase/analysis/classify/stats/MBPredicate.java
@@ -2,6 +2,9 @@ package edu.stanford.futuredata.macrobase.analysis.classify.stats;
 
 import edu.stanford.futuredata.macrobase.util.MacroBaseException;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.function.DoublePredicate;
 import java.util.function.Predicate;
 
@@ -9,7 +12,8 @@ public class MBPredicate {
     public enum PredicateType {
         EQUALS("=="), NOT_EQUALS("!="),
         LESS_THAN("<"), GREATER_THAN(">"),
-        LEQ("<="), GEQ(">=");
+        LEQ("<="), GEQ(">="),
+        STR_RANGE("str_range"), NUM_RANGE("num_range");
 
         private static PredicateType getEnum(final String str) throws MacroBaseException {
             switch (str) {
@@ -25,8 +29,13 @@ public class MBPredicate {
                     return LEQ;
                 case ">=":
                     return GEQ;
+                case "str_range":
+                    return STR_RANGE;
+                case "num_range":
+                    return NUM_RANGE;
                 default:
-                    throw new MacroBaseException("PredicateClassifier: Predicate string " + str +
+                    throw new MacroBaseException(
+                            "PredicateClassifier: Predicate string " + str +
                             " not suppported.");
             }
         }
@@ -37,6 +46,100 @@ public class MBPredicate {
         }
     }
 
+    private boolean isStrPredicate;
+    private DoublePredicate doublePredicate;
+    private Predicate<String> stringPredicate;
+
+    public MBPredicate(
+        final String predicateStr, final Object sentinel
+    ) throws MacroBaseException {
+        PredicateType pt = PredicateType.getEnum(predicateStr);
+        if (pt == PredicateType.NUM_RANGE) {
+            Map<String, Collection<List<Number>>> sentinelValue =
+                    (Map<String, Collection<List<Number>>>) sentinel;
+            Collection<List<Number>> outlierSentinel = sentinelValue.get("outlier");
+            doublePredicate = new DoubleRangePredicate(outlierSentinel);
+            isStrPredicate = false;
+        } else if (pt == PredicateType.STR_RANGE) {
+            Map<String, Collection<List<String>>> sentinelValue =
+                    (Map<String, Collection<List<String>>>) sentinel;
+            Collection<List<String>> outlierSentinel = sentinelValue.get("outlier");
+            stringPredicate = new RangePredicate<>(outlierSentinel);
+            isStrPredicate = true;
+        } else if (sentinel instanceof Number) {
+            double sentinelValue = ((Number) sentinel).doubleValue();
+            doublePredicate = getSimpleDoublePredicate(predicateStr, sentinelValue);
+            isStrPredicate = false;
+        } else if (sentinel instanceof String) {
+            String sentinelValue = (String) sentinel;
+            stringPredicate = getSimpleStrPredicate(predicateStr, sentinelValue);
+            isStrPredicate = true;
+        } else {
+            throw new MacroBaseException("Invalid sentinel type");
+        }
+    }
+    public boolean isStrPredicate() {
+        return isStrPredicate;
+    }
+    public Predicate<String> getStringPredicate() {
+        return stringPredicate;
+    }
+    public DoublePredicate getDoublePredicate() {
+        return doublePredicate;
+    }
+
+    public class DoubleRangePredicate implements DoublePredicate {
+        private Collection<List<Number>> ranges;
+
+        public DoubleRangePredicate(
+                Collection<List<Number>> ranges
+        ) {
+            this.ranges = ranges;
+        }
+
+        @Override
+        public boolean test(double t) {
+            for (List<Number> curRange : ranges) {
+                if (curRange.size() == 1) {
+                    if (t == curRange.get(0).doubleValue()) {
+                        return true;
+                    }
+                } else {
+                    if (curRange.get(0).doubleValue() <= t && t < curRange.get(1).doubleValue()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+
+    public class RangePredicate<T extends Comparable<T>> implements Predicate<T> {
+        private Collection<List<T>> ranges;
+
+        public RangePredicate(
+                Collection<List<T>> ranges
+        ) {
+            this.ranges = ranges;
+        }
+
+        @Override
+        public boolean test(T t) {
+            for (List<T> curRange : ranges) {
+                if (curRange.size() == 1) {
+                    if (curRange.get(0).equals(t)) {
+                        return true;
+                    }
+                } else {
+                    if (curRange.get(0).compareTo(t) <= 0 && t.compareTo(curRange.get(1)) < 0) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
 
     /**
      * @return Lambda function corresponding to the ``predicateStr''. The Lambda function takes in a single
@@ -44,12 +147,11 @@ public class MBPredicate {
      * parameter.)
      * @throws MacroBaseException
      */
-    public static DoublePredicate getDoublePredicate(
+    public static DoublePredicate getSimpleDoublePredicate(
             final String predicateStr,
             final double sentinel
     ) throws MacroBaseException {
         switch (PredicateType.getEnum(predicateStr)) {
-            default:
             case EQUALS:
                 return (double x) -> x == sentinel;
             case NOT_EQUALS:
@@ -62,6 +164,8 @@ public class MBPredicate {
                 return (double x) -> x <= sentinel;
             case GEQ:
                 return (double x) -> x >= sentinel;
+            default:
+                throw new MacroBaseException("Invalid predicate type: "+predicateStr);
         }
     }
 
@@ -71,12 +175,11 @@ public class MBPredicate {
      * parameter.)
      * @throws MacroBaseException
      */
-    public static Predicate<String> getStrPredicate(
+    public static Predicate<String> getSimpleStrPredicate(
             final String predicateStr,
             final String sentinel
     ) throws MacroBaseException {
         switch (PredicateType.getEnum(predicateStr)) {
-            default:
             case EQUALS:
                 return (String x) -> x.equals(sentinel);
             case NOT_EQUALS:
@@ -89,6 +192,9 @@ public class MBPredicate {
                 return (String x) -> x.compareTo(sentinel) <= 0;
             case GEQ:
                 return (String x) -> x.compareTo(sentinel) >= 0;
+            default:
+                throw new MacroBaseException("Invalid predicate type: "+predicateStr);
+
         }
     }
 }

--- a/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifierTest.java
+++ b/lib/src/test/java/edu/stanford/futuredata/macrobase/analysis/classify/PredicateCubeClassifierTest.java
@@ -1,0 +1,103 @@
+package edu.stanford.futuredata.macrobase.analysis.classify;
+
+import edu.stanford.futuredata.macrobase.datamodel.DataFrame;
+import edu.stanford.futuredata.macrobase.datamodel.Schema;
+import edu.stanford.futuredata.macrobase.ingest.CSVDataFrameParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class PredicateCubeClassifierTest {
+    private DataFrame df;
+
+    @Before
+    public void setUp() throws Exception {
+        Map<String, Schema.ColType> colTypes = new HashMap<>();
+        List<String> requiredColumns = new ArrayList<>(Arrays.asList(
+                "location","version","count","mean","std"
+        ));
+        colTypes.put("count", Schema.ColType.DOUBLE);
+        colTypes.put("mean", Schema.ColType.DOUBLE);
+        colTypes.put("std", Schema.ColType.DOUBLE);
+        CSVDataFrameParser loader = new CSVDataFrameParser(
+                "src/test/resources/sample_cubed.csv",
+                requiredColumns
+        );
+        loader.setColumnTypes(colTypes);
+        df = loader.load();
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        PredicateCubeClassifier pc = new PredicateCubeClassifier(
+                "count",
+                "location",
+                "==",
+                "CAN"
+        );
+        pc.process(df);
+        DataFrame output = pc.getResults();
+        assertEquals(df.getNumRows(), output.getNumRows());
+
+        DataFrame outliers = output.filter(
+                pc.getOutputColumnName(), (double d) -> d != 0.0
+        );
+        int numOutliers = outliers.getNumRows();
+        assertTrue(numOutliers == 3);
+    }
+
+    @Test
+    public void testRange() throws Exception {
+        Map<String, Collection<List<String>>> sentinel = new HashMap<>();
+        sentinel.put(
+                "outlier",
+                Arrays.asList(
+                        Arrays.asList("CAN"),
+                        Arrays.asList("USA", "USB")
+                ));
+        PredicateCubeClassifier pc = new PredicateCubeClassifier(
+                "count",
+                "location",
+                "str_range",
+                sentinel
+        );
+        pc.process(df);
+        DataFrame output = pc.getResults();
+        assertEquals(df.getNumRows(), output.getNumRows());
+
+        DataFrame outliers = output.filter(
+                pc.getOutputColumnName(), (double d) -> d != 0.0
+        );
+        int numOutliers = outliers.getNumRows();
+        assertTrue(numOutliers == 4);
+    }
+
+    @Test
+    public void testNumRange() throws Exception {
+        Map<String, Collection<List<Double>>> sentinel = new HashMap<>();
+        sentinel.put(
+                "outlier",
+                Arrays.asList(
+                        Arrays.asList(0.0, 10.0)
+                ));
+        PredicateCubeClassifier pc = new PredicateCubeClassifier(
+                "count",
+                "mean",
+                "num_range",
+                sentinel
+        );
+        pc.process(df);
+        DataFrame output = pc.getResults();
+        assertEquals(df.getNumRows(), output.getNumRows());
+
+        DataFrame outliers = output.filter(
+                pc.getOutputColumnName(), (double d) -> d != 0.0
+        );
+        int numOutliers = outliers.getNumRows();
+        assertTrue(numOutliers == 1);
+    }
+}


### PR DESCRIPTION
Supports custom outlier classifiers based on ranges of strings or numeric quantities.

[[x], [a,b], [c,d]] matches for values v==x or a<=v<b or c<=v<d

See cube_range.json for example usage