### PR TITLE
updated dependencies for security

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-          <version>1.8.0-beta0</version>
+          <version>1.8.0-beta4</version>
         </dependency>
         <dependency>
           <groupId>log4j</groupId>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>[2.7.2,)</version>
+            <version>2.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/legacy/src/test/java/macrobase/conf/MacroBaseConfTest.java
+++ b/legacy/src/test/java/macrobase/conf/MacroBaseConfTest.java
@@ -2,6 +2,7 @@ package macrobase.conf;
 
 import com.google.common.collect.Lists;
 import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import macrobase.ingest.CSVIngester;
 import macrobase.ingest.DiskCachingIngester;
@@ -95,7 +96,7 @@ public class MacroBaseConfTest {
 
     @Test
     public void testParsing() throws Exception {
-        ConfigurationFactory<MacroBaseConf> cfFactory = new ConfigurationFactory<>(MacroBaseConf.class,
+        ConfigurationFactory<MacroBaseConf> cfFactory = new YamlConfigurationFactory<>(MacroBaseConf.class,
                                                                                    null,
                                                                                    Jackson.newObjectMapper(),
                                                                                    "");

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -50,18 +50,18 @@
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
-          <version>1.8.0-beta0</version>
+          <version>1.8.0-beta4</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-          <version>1.8.0-beta0</version>
+          <version>1.8.0-beta4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>28.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -71,13 +71,13 @@
         <dependency>
             <groupId>com.univocity</groupId>
             <artifactId>univocity-parsers</artifactId>
-            <version>2.5.9</version>
+            <version>2.8.2</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
           <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <dropwizard.version>0.9.1</dropwizard.version>
+    <dropwizard.version>1.3.12</dropwizard.version>
     <protostuff.version>1.0.9</protostuff.version>
   </properties>
 

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>21.0</version>
+      <version>28.0-jre</version>
     </dependency>
 
     <dependency>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.8.0-beta0</version>
+      <version>1.8.0-beta4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Run `mvn install; mvn dependency:tree` to confirm all the affected dependencies have been updated.

Also checked to make sure that the server still worked after upgrading.